### PR TITLE
[황혜진] 12주차 과제 제출

### DIFF
--- a/community/src/test/java/efub/assignment/community/account/AccountJpaTest.java
+++ b/community/src/test/java/efub/assignment/community/account/AccountJpaTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import efub.assignment.community.account.domain.Account;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -25,15 +26,23 @@ class AccountJpaTest {
     @Autowired
     private AccountRepository accountRepository;
 
+
     // 성공
     @Test
-    public void Account_saveTest(){
+    public void 사용자_생성_테스트(){
+
+        final String email = "abcd@gmail.com";
+        final String password = "123akd!";
+        final String nickname = "닉네임";
+        final String university = "이화";
+        final String studentId = "123456";
+
         Account account = Account.builder()
-                .email("abcd@gmail.com")
-                .password("123akd!")
-                .nickname("닉네임")
-                .university("이화여대")
-                .studentId("123456")
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .university(university)
+                .studentId(studentId)
                 .build();
 
         testEntityManager.persist(account);
@@ -44,34 +53,49 @@ class AccountJpaTest {
 
     // 성공
     @Test
-    public void Account_save_findByEmailTest() {
-        Account account1 = Account.builder()
-                .email("abcd@gmail.com")
-                .password("123akd!")
-                .nickname("닉네임")
-                .university("이화여대")
-                .studentId("123456")
+    public void 사용자_이메일로조회_테스트() {
+        final String email = "abcd@gmail.com";
+        final String password = "123akd!";
+        final String nickname = "닉네임";
+        final String university = "이화";
+        final String studentId = "123456";
+
+        Account account = Account.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .university(university)
+                .studentId(studentId)
                 .build();
 
-        testEntityManager.persist(account1);
+        testEntityManager.persist(account);
 
-        assertTrue(accountRepository.findByEmail("abcd@gmail.com").isPresent(), "Account should be present");
-        assertThat(accountRepository.findByEmail("abcd@gmail.com").get(),is(account1));
+        assertTrue(accountRepository.findByEmail(email).isPresent(), "Account should be present");
+        assertThat(accountRepository.findByEmail(email).get(),is(account));
     }
 
     // 실패
     @Test
-    public void Account_save_existsByNicknameTest() {
-        Account account1 = Account.builder()
-                .email("abcd@gmail.com")
-                .password("123akd!")
-                .nickname("닉네임")
-                .university("이화여대")
-                .studentId("123456")
+    public void 틀린닉네임으로_사용자존재여부_테스트() {
+
+        final String email = "abcd@gmail.com";
+        final String password = "123akd!";
+        final String nickname = "닉네임";
+        final String university = "이화";
+        final String studentId = "123456";
+
+        Account account = Account.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .university(university)
+                .studentId(studentId)
                 .build();
 
-        testEntityManager.persist(account1);
+        final String wrongNickname = "틀린닉네임";
 
-        assertTrue(accountRepository.existsByNickname("틀린닉네임"));
+        testEntityManager.persist(account);
+
+        assertTrue(accountRepository.existsByNickname(wrongNickname));
     }
 }

--- a/community/src/test/java/efub/assignment/community/account/AccountJpaTest.java
+++ b/community/src/test/java/efub/assignment/community/account/AccountJpaTest.java
@@ -1,0 +1,77 @@
+package efub.assignment.community.account;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import efub.assignment.community.account.domain.Account;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AccountJpaTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    // 성공
+    @Test
+    public void Account_saveTest(){
+        Account account = Account.builder()
+                .email("abcd@gmail.com")
+                .password("123akd!")
+                .nickname("닉네임")
+                .university("이화여대")
+                .studentId("123456")
+                .build();
+
+        testEntityManager.persist(account);
+
+        assertTrue(accountRepository.findById(account.getAccountId()).isPresent(), "Account should be present");
+        assertThat(accountRepository.findById(account.getAccountId()).get(),is(account));
+    }
+
+    // 성공
+    @Test
+    public void Account_save_findByEmailTest() {
+        Account account1 = Account.builder()
+                .email("abcd@gmail.com")
+                .password("123akd!")
+                .nickname("닉네임")
+                .university("이화여대")
+                .studentId("123456")
+                .build();
+
+        testEntityManager.persist(account1);
+
+        assertTrue(accountRepository.findByEmail("abcd@gmail.com").isPresent(), "Account should be present");
+        assertThat(accountRepository.findByEmail("abcd@gmail.com").get(),is(account1));
+    }
+
+    // 실패
+    @Test
+    public void Account_save_existsByNicknameTest() {
+        Account account1 = Account.builder()
+                .email("abcd@gmail.com")
+                .password("123akd!")
+                .nickname("닉네임")
+                .university("이화여대")
+                .studentId("123456")
+                .build();
+
+        testEntityManager.persist(account1);
+
+        assertTrue(accountRepository.existsByNickname("틀린닉네임"));
+    }
+}

--- a/community/src/test/java/efub/assignment/community/account/AccountTest.java
+++ b/community/src/test/java/efub/assignment/community/account/AccountTest.java
@@ -1,0 +1,63 @@
+package efub.assignment.community.account;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import efub.assignment.community.account.domain.Account;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class AccountTest {
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    final String password = "123akd!";
+    final String studentId = "123456";
+    final String nickname = "닉네임";
+    final String university = "이화";
+
+    // 성공
+    @Test
+    public void 사용자속성_반환_테스트(){
+
+        final String email = "abcd@gmail.com";
+
+        Account account = Account.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .university(university)
+                .studentId(studentId)
+                .build();
+
+        assertThat(account.getEmail(), is(email));
+        assertThat(account.getPassword(), is(password));
+        assertThat(account.getNickname(), is(nickname));
+        assertThat(account.getUniversity(), is(university));
+        assertThat(account.getStudentId(), is(studentId));
+    }
+
+    // 실패
+    @Test
+    void 사용자_이메일_널_테스트() {
+
+        final String nullEmail = null;
+
+        Account account = Account.builder()
+                .email(nullEmail)
+                .password(password)
+                .nickname(nickname)
+                .university(university)
+                .studentId(studentId)
+                .build();
+
+        assertThat(accountRepository.save(account), is(account));
+    }
+}

--- a/community/src/test/java/efub/assignment/community/post/PostJpaTest.java
+++ b/community/src/test/java/efub/assignment/community/post/PostJpaTest.java
@@ -1,0 +1,98 @@
+package efub.assignment.community.post;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import efub.assignment.community.account.AccountRepository;
+import efub.assignment.community.account.domain.Account;
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.post.domain.Post;
+import java.util.List;
+import org.hamcrest.collection.IsEmptyCollection;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class PostJpaTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    // 성공
+    @Test
+    public void Post_save_deleteTest() {
+
+        Account account = Account.builder()
+                .email("abcd@gmail.com")
+                .password("123akd!")
+                .nickname("닉네임")
+                .university("이화여대")
+                .studentId("123456")
+                .build();
+
+        Board board = Board.builder()
+                .account(account)
+                .boardName("boardName")
+                .boardDescription("des")
+                .boardNotice("notice")
+                .build();
+
+        Post post = Post.builder()
+                .account(account)
+                .board(board)
+                .title("title")
+                .content("content")
+                .writerOpen("true")
+                .build();
+
+        testEntityManager.persist(post);
+
+        postRepository.delete(post);
+
+        assertThat(postRepository.findAll(), IsEmptyCollection.empty());
+    }
+
+    // 실패
+    @Test
+    public void Post_save_findByIdTest() {
+        Account account = Account.builder()
+                .email("abcd@gmail.com")
+                .password("123akd!")
+                .nickname("닉네임")
+                .university("이화여대")
+                .studentId("123456")
+                .build();
+
+        Board board = Board.builder()
+                .account(account)
+                .boardName("boardName")
+                .boardDescription("des")
+                .boardNotice("notice")
+                .build();
+
+        Post post1 = Post.builder()
+                .account(account)
+                .board(board)
+                .title("title")
+                .content("content")
+                .writerOpen("true")
+                .build();
+
+        testEntityManager.persist(post1);
+
+        assertThat(postRepository.findById(10l).get(), is(post1));
+    }
+}

--- a/community/src/test/java/efub/assignment/community/post/PostTest.java
+++ b/community/src/test/java/efub/assignment/community/post/PostTest.java
@@ -1,17 +1,12 @@
 package efub.assignment.community.post;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import efub.assignment.community.account.AccountRepository;
 import efub.assignment.community.account.domain.Account;
 import efub.assignment.community.board.domain.Board;
 import efub.assignment.community.post.domain.Post;
-import java.util.List;
-import org.hamcrest.collection.IsEmptyCollection;
+import efub.assignment.community.post.dto.PostUpdateDto;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -19,24 +14,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-public class PostJpaTest {
-
-    @Autowired
-    private TestEntityManager testEntityManager;
+public class PostTest {
 
     @Autowired
     private PostRepository postRepository;
 
     static Account account;
     static Board board;
-    static String title;
-    static String content;
-    static String writerOpen;
+
 
     @BeforeAll
     static void beforeAll() {
@@ -54,34 +43,15 @@ public class PostJpaTest {
                 .boardDescription("des")
                 .boardNotice("notice")
                 .build();
-
-        title = "title";
-        content = "content";
-        writerOpen = "true";
     }
 
     // 성공
     @Test
-    public void 게시글_삭제_테스트() {
+    public void 게시글_제목본문_수정_테스트(){
 
-        Post post = Post.builder()
-                .account(account)
-                .board(board)
-                .title(title)
-                .content(content)
-                .writerOpen(writerOpen)
-                .build();
-
-        testEntityManager.persist(post);
-
-        postRepository.delete(post);
-
-        assertThat(postRepository.findAll(), IsEmptyCollection.empty());
-    }
-
-    // 실패
-    @Test
-    public void 존재하지않는_ID_게시글조회_테스트() {
+        final String title = "title";
+        final String content = "content";
+        final String writerOpen = "open";
 
         Post post1 = Post.builder()
                 .account(account)
@@ -91,8 +61,31 @@ public class PostJpaTest {
                 .writerOpen(writerOpen)
                 .build();
 
-        testEntityManager.persist(post1);
+        final String updatedTitle = "변경title";
+        final String updatedContent = "변경content";
 
-        assertThat(postRepository.findById(10l).get(), is(post1));
+        post1.update(new PostUpdateDto(updatedTitle,updatedContent));
+
+        assertThat(post1.getTitle(), is(updatedTitle));
+        assertThat(post1.getContent(), is(updatedContent));
+    }
+
+    // 실패
+    @Test
+    public void 게시글_긴제목_저장_테스트() {
+
+        final String tooLongTitle = "This title is way too long and exceeds the maximum length of 50 characters";
+        final String content = "content";
+        final String writerOpen = "open";
+
+        Post post = Post.builder()
+                .account(account)
+                .board(board)
+                .title(tooLongTitle)
+                .content(content)
+                .writerOpen(writerOpen)
+                .build();
+
+        assertThat(postRepository.save(post), is(post));
     }
 }


### PR DESCRIPTION
# 구현 기능
- account, post 엔티티&레포지토리 테스트 코드 작성

# 과제 정리
- account entity
   - 사용자 이메일 널 테스트 : account email 속성에 null값이 저장되지 않아야 하는 실패 테스트 코드
   - 사용자 속성 반환 테스트 : account 속성값을 모두 올바르게 반환하는 성공 테스트 코드
![accounttest](https://github.com/user-attachments/assets/fdc5aa31-b241-47d7-9fbb-eadd45f12372)

- account repository
   - 사용자 생성 테스트 : account가 잘 저장되어야 하는 성공 테스트
   - 사용자 이메일로 조회 테스트 : 이메일로 사용자를 조회했을 때, 올바른 account를 반환하는 성공 테스트
   - 틀린 닉네임으로 사용자 존재여부 테스트 : 틀린 닉네임으로 사용자 존재여부를 조회했을 때, false가 나오는 실패 테스트
![accountRepositorytest](https://github.com/user-attachments/assets/8928459f-da2f-44b3-bbfc-5c631376b6da)

- post entity
   - 게시글 긴제목 저장 테스트 : 길이 제한을 넘는 긴 제목을 저장했을 때 실패하는 테스트
   - 게시글 제목분문 수정 테스트 : 게시글의 제목과 본문이 잘 수정되어야 하는 성공 테스트
![posttest](https://github.com/user-attachments/assets/d0fa4f76-bfe5-4bfa-b412-c5cce77e222f)

- post repository
   - 게시글 삭제 테스트 : 게시글이 잘 삭제되어서 post가 존재하지 않아야 하는 성공 테스트
   - 존재하지 않는 id로 게시글 조회 테스트 : 존재하지 않는 id로 게시글을 조회했을 때 실패하는 테스트
![postRepositorytest](https://github.com/user-attachments/assets/06f5024c-fc59-49b4-b085-a42177f5387c)


- 포스트맨
![account test](https://github.com/user-attachments/assets/9f244230-a693-4627-91ca-679362ee9e96)
![post test fail](https://github.com/user-attachments/assets/5aeab03c-340b-45c2-853a-568add9b67a6)


