### PR TITLE
[황채린] 12주차 과제 제출

### DIFF
--- a/community/src/test/java/efub/assignment/community/member/domain/MemberTest.java
+++ b/community/src/test/java/efub/assignment/community/member/domain/MemberTest.java
@@ -1,0 +1,90 @@
+package efub.assignment.community.member.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemberTest {
+
+    @Test
+    @DisplayName("Member 생성 테스트 성공")
+    void createMemberEntity(){
+        //given
+        String email = "cococofls@ewhain.net";
+        String nickname = "채린";
+        String password = "chaerinPassword";
+        String university = "이화여자대학교";
+        String studentId = "2176429";
+
+        //when
+        Member member = Member.builder()
+                .email(email)
+                .nickname(nickname)
+                .password(password)
+                .university(university)
+                .studentId(studentId)
+                .build();
+
+        //then
+        assertEquals(email,member.getEmail());
+        assertEquals(nickname,member.getNickname());
+        assertEquals(password,member.getPassword());
+        assertEquals(university,member.getUniversity());
+        assertEquals(studentId,member.getStudentId());
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 테스트 성공")
+    void changeNickname(){
+        //given
+        String email = "cococofls@ewhain.net";
+        String nickname = "채린";
+        String password = "chaerinPassword";
+        String university = "이화여자대학교";
+        String studentId = "2176429";
+
+        Member member = Member.builder()
+                .email(email)
+                .nickname(nickname)
+                .password(password)
+                .university(university)
+                .studentId(studentId)
+                .build();
+
+        String newNickname = "새채린";
+
+        //when
+        member.changeNickname(newNickname);
+
+        //then
+        assertEquals(newNickname,member.getNickname());
+    }
+
+    @Test
+    @DisplayName("계정 비활성화 테스트 실패")
+    void deactivateAccount_Fail(){
+        //given
+        String email = "cococofls@ewhain.net";
+        String nickname = "채린";
+        String password = "chaerinPassword";
+        String university = "이화여자대학교";
+        String studentId = "2176429";
+
+        Member member = Member.builder()
+                .email(email)
+                .nickname(nickname)
+                .password(password)
+                .university(university)
+                .studentId(studentId)
+                .build();
+
+        //when
+        member.deactivateAccount();
+
+        //then
+        assertEquals(MemberStatus.REGISTERED,member.getStatus(),"멤버 상태는 UNREGISTERED 여야 합니다.");
+    }
+    
+
+}

--- a/community/src/test/java/efub/assignment/community/member/repository/MemberRepositoryTest.java
+++ b/community/src/test/java/efub/assignment/community/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,127 @@
+package efub.assignment.community.member.repository;
+
+import efub.assignment.community.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE,
+    connection = EmbeddedDatabaseConnection.H2)
+public class MemberRepositoryTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("멤버 저장 테스트")
+    void saveMember(){
+        //given
+        String email = "cococofls@ewhain.net";
+        String nickname = "채린";
+        String password = "chaerinPassword";
+        String university = "이화여자대학교";
+        String studentId = "2176429";
+
+        Member member = Member.builder()
+                .email(email)
+                .nickname(nickname)
+                .password(password)
+                .university(university)
+                .studentId(studentId)
+                .build();
+
+        //when
+        testEntityManager.persist(member);
+
+        //then
+        assertEquals(member,testEntityManager.find(Member.class,member.getMemberId()));
+    }
+
+    @Test
+    @DisplayName("닉네임으로 멤버 조회 테스트")
+    void searchMemberByNickname(){
+        //given
+        String email = "cococofls@ewhain.net";
+        String nickname = "채린";
+        String password = "chaerinPassword";
+        String university = "이화여자대학교";
+        String studentId = "2176429";
+
+        Member member1 = Member.builder()
+                .email(email)
+                .nickname(nickname)
+                .password(password)
+                .university(university)
+                .studentId(studentId)
+                .build();
+
+        testEntityManager.persist(member1);
+
+        //when
+        Member member2 = memberRepository.findByNickname(nickname).get();
+
+        //then
+        assertEquals(member1,member2);
+    }
+
+    @Test
+    @DisplayName("이메일로 멤버 존재 여부 확인 테스트")
+    void checkMemberExistsByEmail(){
+        //given
+        String email = "cococofls@ewhain.net";
+        String nickname = "채린";
+        String password = "chaerinPassword";
+        String university = "이화여자대학교";
+        String studentId = "2176429";
+
+        Member member1 = Member.builder()
+                .email(email)
+                .nickname(nickname)
+                .password(password)
+                .university(university)
+                .studentId(studentId)
+                .build();
+
+        testEntityManager.persist(member1);
+
+        //when & then
+        assertTrue(memberRepository.existsByEmail(email));
+    }
+
+    @Test
+    @DisplayName("이메일로 멤버 존재 여부 확인 테스트 실패")
+    void checkMemberExistsByEmail_Fail(){
+        //given
+        String email = "cococofls@ewhain.net";
+        String nickname = "채린";
+        String password = "chaerinPassword";
+        String university = "이화여자대학교";
+        String studentId = "2176429";
+
+        Member member1 = Member.builder()
+                .email(email)
+                .nickname(nickname)
+                .password(password)
+                .university(university)
+                .studentId(studentId)
+                .build();
+
+        testEntityManager.persist(member1);
+
+        //when & then
+        assertTrue(memberRepository.existsByEmail("없는 이메일"));
+    }
+
+
+}
+

--- a/community/src/test/java/efub/assignment/community/post/domain/PostTest.java
+++ b/community/src/test/java/efub/assignment/community/post/domain/PostTest.java
@@ -1,0 +1,115 @@
+package efub.assignment.community.post.domain;
+
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.post.repository.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE,
+        connection = EmbeddedDatabaseConnection.H2)
+class PostTest {
+
+    @Autowired
+    TestEntityManager testEntityManager;
+
+    static Member member;
+    static Board board;
+
+    @BeforeEach
+    void setup(){
+        member = Member.builder()
+                .email("cococofls@ewhain.net")
+                .nickname("채린")
+                .password("chaerinPassword")
+                .university("이화여자대학교")
+                .studentId("2176429")
+                .build();
+
+        testEntityManager.persist(member);
+
+        board = Board.builder()
+                .member(member)
+                .name("테스트용 게시판")
+                .description("설명")
+                .build();
+
+        testEntityManager.persist(board);
+    }
+
+    @Test
+    @DisplayName("Post 생성 테스트")
+    void createPostEntity(){
+        //given
+        boolean anonymous = true;
+        String content = "글 내용";
+
+        //when
+        Post post = Post.builder()
+                .board(board)
+                .member(member)
+                .anonymous(anonymous)
+                .content(content)
+                .build();
+
+        //then
+        assertEquals(anonymous,post.isAnonymous());
+        assertEquals(content,post.getContent());
+        assertEquals(board,post.getBoard());
+        assertEquals(member,post.getMember());
+    }
+
+    @Test
+    @DisplayName("Post 내용이 1000자가 넘는 경우 테스트")
+    void createPostEntity_Fail_WhenContentIsTooLong(){
+        //given
+        boolean anonymous = true;
+        String content = "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+
+        Post post = Post.builder()
+                .board(board)
+                .member(member)
+                .anonymous(anonymous)
+                .content(content)
+                .build();
+
+        //when & then
+        testEntityManager.persist(post);
+    }
+
+    @Test
+    @DisplayName("Post 내용 변경 테스트")
+    void updatePostContent(){
+        //given
+        boolean anonymous = true;
+        String content = "글 내용";
+
+        Post post = Post.builder()
+                .board(board)
+                .member(member)
+                .anonymous(anonymous)
+                .content(content)
+                .build();
+
+        String newContent = "글 새 내용";
+
+        //when
+        post.updateContent(newContent);
+
+        //then
+        assertEquals(newContent,post.getContent());
+    }
+
+
+
+
+}

--- a/community/src/test/java/efub/assignment/community/post/repository/PostRepositoryTest.java
+++ b/community/src/test/java/efub/assignment/community/post/repository/PostRepositoryTest.java
@@ -1,0 +1,127 @@
+package efub.assignment.community.post.repository;
+
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.post.domain.Post;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE,
+        connection = EmbeddedDatabaseConnection.H2)
+public class PostRepositoryTest {
+
+    @Autowired
+    TestEntityManager testEntityManager;
+    @Autowired
+    PostRepository postRepository;
+
+    static Member member;
+    static Board board;
+
+    @BeforeEach
+    void setup(){
+        member = Member.builder()
+                .email("cococofls@ewhain.net")
+                .nickname("채린")
+                .password("chaerinPassword")
+                .university("이화여자대학교")
+                .studentId("2176429")
+                .build();
+
+        testEntityManager.persist(member);
+
+        board = Board.builder()
+                .member(member)
+                .name("테스트용 게시판")
+                .description("설명")
+                .build();
+
+        testEntityManager.persist(board);
+    }
+
+    @Test
+    @DisplayName("Post 저장 테스트")
+    void savePost(){
+        //given
+        boolean anonymous = true;
+        String content = "글 내용";
+
+        Post post = Post.builder()
+                .board(board)
+                .member(member)
+                .anonymous(anonymous)
+                .content(content)
+                .build();
+
+        //when
+        testEntityManager.persist(post);
+
+        //then
+        assertEquals(post,testEntityManager.find(Post.class,post.getPostId()));
+    }
+
+    @Test
+    @DisplayName("BoardId로 Post 목록 조회 테스트")
+    void searchPostListByBoardId(){
+        //given
+        boolean anonymous = true;
+        String content = "글 내용";
+
+        Post post1 = Post.builder()
+                .board(board)
+                .member(member)
+                .anonymous(anonymous)
+                .content(content)
+                .build();
+
+        Post post2 = Post.builder()
+                .board(board)
+                .member(member)
+                .anonymous(anonymous)
+                .content(content)
+                .build();
+
+        testEntityManager.persist(post1);
+        testEntityManager.persist(post2);
+
+        //when
+        List<Post> posts = postRepository.findByBoard_BoardId(board.getBoardId());
+
+        //then
+        assertEquals(post1,posts.get(0));
+        assertEquals(post2,posts.get(1));
+    }
+
+    @Test
+    @DisplayName("Post 조회 테스트 실패")
+    void deletePost_Fail(){
+        //given
+        boolean anonymous = true;
+        String content = "글 내용";
+
+        Post post = Post.builder()
+                .board(board)
+                .member(member)
+                .anonymous(anonymous)
+                .content(content)
+                .build();
+
+        testEntityManager.persist(post);
+
+        //when & then
+        assertTrue(postRepository.existsById((long)1234));
+    }
+
+
+}


### PR DESCRIPTION
# 구현 기능
- Member 엔티티/레포지토리 테스트 코드 작성
- Post 엔티티/레포지토리 테스트 코드 작성
- [세미나 내용 정리](https://peaceful-neighbor-4e7.notion.site/TDD-f93b4c2a49d645f0a05e1ede85ea98fa?pvs=4)

# 과제 정리

-  Member 엔티티
   - Member 생성에 성공하는 테스트 코드 작성
   - 닉네임 변경에 성공하는 테스트 코드 작성
   - 계정 비활성화 후 Member 상태가 여전히 REGISTERED 라면 실패하는 테스트 코드 작성
  <img width="875" alt="image" src="https://github.com/user-attachments/assets/ee07c6a9-bd47-465d-8286-51012e885cc9">


-  Member 레포지토리
   - Member 저장에 성공하는 테스트 코드 작성
   - 닉네임으로 Member 조회에 성공하는 테스트 코드 작성
   - 이메일로 Member 존재 여부 확인에 성공하는 테스트 코드 작성
   - 존재하지 않는 이메일로 Member 조회 시 실패하는 테스트 코드 작성
  <img width="918" alt="image" src="https://github.com/user-attachments/assets/14b7b19c-3f10-4d16-aa4d-8e2279dc0e42">


-  Post 엔티티
   - Post 생성에 성공하는 테스트 코드 작성
   - Post 내용 변경에 성공하는 테스트 코드 작성
   - Post 의 내용이 1000자가 넘는 경우 실패하는 테스트 코드 작성
  <img width="923" alt="image" src="https://github.com/user-attachments/assets/6370927e-51b3-48d2-a9f6-04f6c087609a">


-  Post 레포지토리
   - Post 저장에 성공하는 테스트 코드 작성
   - BoardId로 Post 목록 조회에 성공하는 테스트 코드 작성
   - 존재하지 않는 Id로 Post 조회 시 실패하는 테스트 코드 작성
  <img width="915" alt="image" src="https://github.com/user-attachments/assets/fb94b520-ae6e-4b1d-afaa-8990844a653a">


# 어려웠던 점(생략 가능)
- 실패하는 테스트 코드를 떠올리고 작성해내는 게 생각보다 어려웠다. 