### PR TITLE
[이서현] 12주차 과제 제출

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -2,7 +2,7 @@ name: Deploy to Amazon EC2
 
 on:
   push:
-    branches: [ "main", "deploy" ] # push가 될 때 워크플로우를 실행할 브랜치 리스트
+    branches: [ "deploy" ] # push가 될 때 워크플로우를 실행할 브랜치 리스트
 
 jobs:
   deploy:

--- a/community/build.gradle
+++ b/community/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/community/src/main/java/efub/assignment/community/account/controller/AccountController.java
+++ b/community/src/main/java/efub/assignment/community/account/controller/AccountController.java
@@ -19,30 +19,28 @@ public class AccountController {
     @PostMapping
     @ResponseStatus(value = HttpStatus.CREATED)
     public AccountResponseDto signUp(@RequestBody @Valid final SignUpRequestDto requestDto){
-        Long id = accountService.signUp(requestDto);
-        Account findAccount = accountService.findAccountById(id);
-        return AccountResponseDto.from(findAccount);
+        Account account = accountService.signUp(requestDto);
+        return AccountResponseDto.from(account);
     }
 
     @GetMapping("/{account_id}")
     @ResponseStatus(value = HttpStatus.OK)
     public AccountResponseDto getAccount(@PathVariable Long account_id){
-        Account findAccount = accountService.findAccountById(account_id);
-        return AccountResponseDto.from(findAccount);
+        Account account = accountService.findAccountById(account_id);
+        return AccountResponseDto.from(account);
     }
 
     @PatchMapping("/profile/{account_id}")
     @ResponseStatus(value = HttpStatus.OK)
     public AccountResponseDto update(@PathVariable final Long account_id, @RequestBody @Valid final AccountUpdateRequestDto requestDto){
-        Long id = accountService.update(account_id,requestDto);
-        Account findAccount = accountService.findAccountById(id);
-        return AccountResponseDto.from(findAccount);
+        Account account = accountService.update(account_id,requestDto);
+        return AccountResponseDto.from(account);
     }
 
     @PatchMapping("/{account_id}")
     @ResponseStatus(value = HttpStatus.OK)
     public String withdraw(@PathVariable Long account_id){
         accountService.withdraw(account_id);
-        return "삭제가 완료되었습니다.";
+        return "계쩡 비활성화가 완료되었습니다.";
     }
 }

--- a/community/src/main/java/efub/assignment/community/account/controller/AccountController.java
+++ b/community/src/main/java/efub/assignment/community/account/controller/AccountController.java
@@ -33,7 +33,7 @@ public class AccountController {
     @PatchMapping("/profile/{account_id}")
     @ResponseStatus(value = HttpStatus.OK)
     public AccountResponseDto update(@PathVariable final Long account_id, @RequestBody @Valid final AccountUpdateRequestDto requestDto){
-        Account account = accountService.update(account_id,requestDto);
+        Account account = accountService.updateAccount(account_id,requestDto);
         return AccountResponseDto.from(account);
     }
 

--- a/community/src/main/java/efub/assignment/community/account/domain/Account.java
+++ b/community/src/main/java/efub/assignment/community/account/domain/Account.java
@@ -31,7 +31,7 @@ public class Account extends BaseTimeEntity {
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false, updatable = true, length = 16)
+    @Column(nullable = false, length = 16)
     private String nickname;
 
     @Column(nullable = false, length = 20)

--- a/community/src/main/java/efub/assignment/community/account/dto/SignUpRequestDto.java
+++ b/community/src/main/java/efub/assignment/community/account/dto/SignUpRequestDto.java
@@ -4,13 +4,11 @@ import efub.assignment.community.account.domain.Account;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class SignUpRequestDto {
     @NotBlank(message = "이메일은 필수입니다.")
       @Email(message = "유효하지 않은 이메일 형식입니다.")
@@ -30,15 +28,6 @@ public class SignUpRequestDto {
 
     @NotBlank(message = "학번은 필수입니다.")
     private String studentId;
-
-    @Builder
-    public SignUpRequestDto(String email, String password, String nickname, String university, String studentId){
-        this.email = email;
-        this.password = password;
-        this.nickname = nickname;
-        this.university = university;
-        this.studentId = studentId;
-    }
 
     public Account toEntity(){
         return Account.builder()

--- a/community/src/main/java/efub/assignment/community/account/repository/AccountRepository.java
+++ b/community/src/main/java/efub/assignment/community/account/repository/AccountRepository.java
@@ -1,4 +1,4 @@
-package efub.assignment.community.account;
+package efub.assignment.community.account.repository;
 
 import efub.assignment.community.account.domain.Account;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/community/src/main/java/efub/assignment/community/account/service/AccountService.java
+++ b/community/src/main/java/efub/assignment/community/account/service/AccountService.java
@@ -15,12 +15,11 @@ import org.springframework.stereotype.Service;
 public class AccountService {
     private final AccountRepository accountRepository;
 
-    public Long signUp(SignUpRequestDto requestDto){
+    public Account signUp(SignUpRequestDto requestDto){
         if(existsByEmail(requestDto.getEmail())){
             throw new IllegalArgumentException("이미 존재하는 email입니다."+requestDto.getEmail());
         }
-        Account account = accountRepository.save(requestDto.toEntity());
-        return account.getAccountId();
+        return accountRepository.save(requestDto.toEntity());
     }
 
     @Transactional(readOnly = true)
@@ -45,7 +44,7 @@ public class AccountService {
                 .orElseThrow(()-> new EntityNotFoundException("해당 email을 가진 Account를 찾을 수 없습니다. email="+email));
     }
 
-    public Long update(Long account_id, AccountUpdateRequestDto requestDto){
+    public Account update(Long account_id, AccountUpdateRequestDto requestDto){
         if(existsByEmail(requestDto.getEmail())){ // 변경하려는 이메일이 이미 등록되어 있는지
             if(!account_id.equals(findAccountByEmail(requestDto.getEmail()).getAccountId())){  // 등록되어있는 이메일이 자신의 계정 이메일이 아니면 IllegalArgumentException "이미 존재하는 email입니다."
                 throw new IllegalArgumentException("이미 존재하는 email입니다."+requestDto.getEmail());
@@ -58,7 +57,7 @@ public class AccountService {
             }
         }
         account.updateAccount(requestDto.getEmail(),requestDto.getNickname(),requestDto.getPassword());
-        return account.getAccountId();
+        return account;
     }
 
     public void withdraw(Long account_id){

--- a/community/src/main/java/efub/assignment/community/account/service/AccountService.java
+++ b/community/src/main/java/efub/assignment/community/account/service/AccountService.java
@@ -1,9 +1,9 @@
 package efub.assignment.community.account.service;
 
-import efub.assignment.community.account.AccountRepository;
 import efub.assignment.community.account.domain.Account;
 import efub.assignment.community.account.dto.AccountUpdateRequestDto;
 import efub.assignment.community.account.dto.SignUpRequestDto;
+import efub.assignment.community.account.repository.AccountRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -44,13 +44,19 @@ public class AccountService {
                 .orElseThrow(()-> new EntityNotFoundException("해당 email을 가진 Account를 찾을 수 없습니다. email="+email));
     }
 
-    public Account update(Long account_id, AccountUpdateRequestDto requestDto){
+    @Transactional(readOnly = true)
+    public Account findAccountByNickname(String name){
+        return accountRepository.findByNickname(name)
+                .orElseThrow(()-> new EntityNotFoundException("해당 nickname를 가진 Account를 찾을 수 없습니다. nickname="+name));
+    }
+
+    public Account updateAccount(Long accountId, AccountUpdateRequestDto requestDto){
         if(existsByEmail(requestDto.getEmail())){ // 변경하려는 이메일이 이미 등록되어 있는지
-            if(!account_id.equals(findAccountByEmail(requestDto.getEmail()).getAccountId())){  // 등록되어있는 이메일이 자신의 계정 이메일이 아니면 IllegalArgumentException "이미 존재하는 email입니다."
+            if(!accountId.equals(findAccountByEmail(requestDto.getEmail()).getAccountId())){  // 등록되어있는 이메일이 자신의 계정 이메일이 아니면 IllegalArgumentException "이미 존재하는 email입니다."
                 throw new IllegalArgumentException("이미 존재하는 email입니다."+requestDto.getEmail());
             }
         }
-        Account account = findAccountById(account_id);
+        Account account = findAccountById(accountId);
         if(account.getNickname() != requestDto.getNickname()){
             if(existsByNickname(requestDto.getNickname())){
                 throw new IllegalArgumentException("이미 존재하는 nickname입니다."+requestDto.getNickname());
@@ -60,14 +66,9 @@ public class AccountService {
         return account;
     }
 
-    public void withdraw(Long account_id){
-        Account account = findAccountById(account_id);
+    public void withdraw(Long accountId){
+        Account account = findAccountById(accountId);
         account.withdrawAccount();
     }
 
-    @Transactional(readOnly = true) //닉네임으로 해당 계정 찾는 메소드
-    public Account findAccountByNickname(String name){
-        return accountRepository.findByNickname(name)
-                .orElseThrow(()-> new EntityNotFoundException("해당 nickname를 가진 Account를 찾을 수 없습니다. nickname="+name));
-    }
 }

--- a/community/src/main/java/efub/assignment/community/board/repository/BoardRepository.java
+++ b/community/src/main/java/efub/assignment/community/board/repository/BoardRepository.java
@@ -1,4 +1,4 @@
-package efub.assignment.community.board;
+package efub.assignment.community.board.repository;
 
 import efub.assignment.community.board.domain.Board;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/community/src/main/java/efub/assignment/community/board/service/BoardService.java
+++ b/community/src/main/java/efub/assignment/community/board/service/BoardService.java
@@ -2,7 +2,7 @@ package efub.assignment.community.board.service;
 
 import efub.assignment.community.account.domain.Account;
 import efub.assignment.community.account.service.AccountService;
-import efub.assignment.community.board.BoardRepository;
+import efub.assignment.community.board.repository.BoardRepository;
 import efub.assignment.community.board.domain.Board;
 import efub.assignment.community.board.dto.BoardRequestDto;
 import efub.assignment.community.board.dto.BoardUpdateDto;

--- a/community/src/main/java/efub/assignment/community/message/service/MessageService.java
+++ b/community/src/main/java/efub/assignment/community/message/service/MessageService.java
@@ -3,7 +3,6 @@ package efub.assignment.community.message.service;
 
 import efub.assignment.community.account.domain.Account;
 import efub.assignment.community.account.service.AccountService;
-import efub.assignment.community.board.domain.Board;
 import efub.assignment.community.message.domain.Message;
 import efub.assignment.community.message.dto.MessageRequestDto;
 import efub.assignment.community.message.repository.MessageRepository;

--- a/community/src/main/java/efub/assignment/community/notice/service/NoticeService.java
+++ b/community/src/main/java/efub/assignment/community/notice/service/NoticeService.java
@@ -2,12 +2,9 @@ package efub.assignment.community.notice.service;
 
 import efub.assignment.community.account.domain.Account;
 import efub.assignment.community.account.service.AccountService;
-import efub.assignment.community.board.domain.Board;
-import efub.assignment.community.comment.domain.Comment;
 import efub.assignment.community.notice.domain.Notice;
 import efub.assignment.community.notice.repository.NoticeRepository;
 import efub.assignment.community.post.domain.Post;
-import efub.assignment.community.post.dto.PostRequestDto;
 import efub.assignment.community.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/community/src/main/java/efub/assignment/community/post/domain/Post.java
+++ b/community/src/main/java/efub/assignment/community/post/domain/Post.java
@@ -63,8 +63,9 @@ public class Post extends BaseTimeEntity {
         this.writerOpen = writerOpen;
     }
 
-    public void update(PostUpdateDto dto){
-        this.title = dto.getTitle();
-        this.content = dto.getContent();
+    public void update(String title, String content, String writerOpen){
+        this.title = title;
+        this.content = content;
+        this.writerOpen = writerOpen;
     }
 }

--- a/community/src/main/java/efub/assignment/community/post/dto/PostUpdateDto.java
+++ b/community/src/main/java/efub/assignment/community/post/dto/PostUpdateDto.java
@@ -13,9 +13,13 @@ public class PostUpdateDto {
     @NotBlank(message = "글의 내용은 필수입니다.")
     private String content;
 
+    @NotBlank(message = "글의 공개 상태는 필수입니다.")
+    private String writerOpen;
+
     @Builder
-    public PostUpdateDto(String title, String content){
+    public PostUpdateDto(String title, String content, String writerOpen){
         this.title = title;
         this.content = content;
+        this.writerOpen = writerOpen;
     }
 }

--- a/community/src/main/java/efub/assignment/community/post/repository/PostHeartRepository.java
+++ b/community/src/main/java/efub/assignment/community/post/repository/PostHeartRepository.java
@@ -1,4 +1,4 @@
-package efub.assignment.community.post;
+package efub.assignment.community.post.repository;
 
 import efub.assignment.community.account.domain.Account;
 import efub.assignment.community.post.domain.Post;

--- a/community/src/main/java/efub/assignment/community/post/repository/PostRepository.java
+++ b/community/src/main/java/efub/assignment/community/post/repository/PostRepository.java
@@ -1,4 +1,4 @@
-package efub.assignment.community.post;
+package efub.assignment.community.post.repository;
 
 import efub.assignment.community.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/community/src/main/java/efub/assignment/community/post/service/PostHeartService.java
+++ b/community/src/main/java/efub/assignment/community/post/service/PostHeartService.java
@@ -2,7 +2,7 @@ package efub.assignment.community.post.service;
 
 import efub.assignment.community.account.domain.Account;
 import efub.assignment.community.account.service.AccountService;
-import efub.assignment.community.post.PostHeartRepository;
+import efub.assignment.community.post.repository.PostHeartRepository;
 import efub.assignment.community.post.domain.Post;
 import efub.assignment.community.post.domain.PostHeart;
 import lombok.RequiredArgsConstructor;

--- a/community/src/main/java/efub/assignment/community/post/service/PostService.java
+++ b/community/src/main/java/efub/assignment/community/post/service/PostService.java
@@ -6,7 +6,7 @@ import efub.assignment.community.account.service.AccountService;
 import efub.assignment.community.board.domain.Board;
 import efub.assignment.community.board.service.BoardService;
 import efub.assignment.community.exception.CustomDeleteException;
-import efub.assignment.community.post.PostRepository;
+import efub.assignment.community.post.repository.PostRepository;
 import efub.assignment.community.post.domain.Post;
 import efub.assignment.community.post.dto.PostRequestDto;
 import efub.assignment.community.post.dto.PostUpdateDto;

--- a/community/src/main/java/efub/assignment/community/post/service/PostService.java
+++ b/community/src/main/java/efub/assignment/community/post/service/PostService.java
@@ -55,7 +55,7 @@ public class PostService {
 
     public Long updatePost(Long postId, PostUpdateDto dto){
         Post post = findPostById(postId);
-        post.update(dto);
+        post.update(dto.getTitle(), dto.getContent(), dto.getWriterOpen());
         return post.getPostId();
     }
 

--- a/community/src/main/java/efub/assignment/community/post/service/PostService.java
+++ b/community/src/main/java/efub/assignment/community/post/service/PostService.java
@@ -6,7 +6,6 @@ import efub.assignment.community.account.service.AccountService;
 import efub.assignment.community.board.domain.Board;
 import efub.assignment.community.board.service.BoardService;
 import efub.assignment.community.exception.CustomDeleteException;
-import efub.assignment.community.exception.ErrorCode;
 import efub.assignment.community.post.PostRepository;
 import efub.assignment.community.post.domain.Post;
 import efub.assignment.community.post.dto.PostRequestDto;
@@ -54,15 +53,15 @@ public class PostService {
         return post;
     }
 
-    public Long updatePost(Long post_id, PostUpdateDto dto){
-        Post post = findPostById(post_id);
+    public Long updatePost(Long postId, PostUpdateDto dto){
+        Post post = findPostById(postId);
         post.update(dto);
         return post.getPostId();
     }
 
-    public void deletePost(Long post_id, Long account_id){
-        Post post = findPostById(post_id);
-        if(account_id!=post.getAccount().getAccountId()){
+    public void deletePost(Long postId, Long accountId){
+        Post post = findPostById(postId);
+        if(accountId!=post.getAccount().getAccountId()){
             throw new CustomDeleteException(PERMISSION_REJECTED_USER);
         }
         postRepository.delete(post);

--- a/community/src/test/java/efub/assignment/community/account/domain/AccountTest.java
+++ b/community/src/test/java/efub/assignment/community/account/domain/AccountTest.java
@@ -1,0 +1,94 @@
+package efub.assignment.community.account.domain;
+
+import org.junit.jupiter.api.*;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class AccountTest {
+
+    @Order(1)
+    @Test
+    void account_build_test() {
+        // given
+        String email = "email@domain.com";
+        String password = "password";
+        String nickname = "사용자명";
+        String university = "Test Univ.";
+        String studentId = "1234";
+
+        // then
+        Account account = Account.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .university(university)
+                .studentId(studentId)
+                .build();
+
+        // then
+        assertEquals(email, account.getEmail());
+        assertEquals(password, account.getPassword());
+        assertEquals(nickname, account.getNickname());
+        assertEquals(university, account.getUniversity());
+        assertEquals(studentId, account.getStudentId());
+    }
+
+    @Order(2)
+    @Test
+    void updateAccount_test() {
+        // given
+        String email = "email@domain.com";
+        String password = "password";
+        String nickname = "사용자명";
+        String university = "Test Univ.";
+        String studentId = "1234";
+
+        Account account = Account.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .university(university)
+                .studentId(studentId)
+                .build();
+
+        // when
+        String newEmail = "newemail@domain.com";
+        String newNickname = "새 사용자명";
+        String newPassword = "newpassword";
+
+        account.updateAccount(newEmail, newNickname, newPassword);
+
+        // then
+        assertEquals(newEmail, account.getEmail());
+        assertEquals(newNickname, account.getNickname());
+        assertEquals(newPassword, account.getPassword());
+    }
+
+    @Test
+    void withdrawAccount_test() {
+        // given
+        String email = "email@domain.com";
+        String password = "password";
+        String nickname = "사용자명";
+        String university = "Test Univ.";
+        String studentId = "1234";
+
+        Account account = Account.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .university(university)
+                .studentId(studentId)
+                .build();
+
+        // when
+        account.withdrawAccount();
+
+        // then
+        assertEquals(account.getStatus(), AccountStatus.UNREGISTERED);
+    }
+}

--- a/community/src/test/java/efub/assignment/community/account/repository/AccountRepositoryTest.java
+++ b/community/src/test/java/efub/assignment/community/account/repository/AccountRepositoryTest.java
@@ -37,8 +37,13 @@ class AccountRepositoryTest {
         String university = "Test Univ.";
         String studentId = "1234";
 
-        SignUpRequestDto requestDto = new SignUpRequestDto(email, password, nickname, university, studentId);
-        testAccount = requestDto.toEntity();
+        testAccount = Account.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .university(university)
+                .studentId(studentId)
+                .build();
         testEntityManager.persist(testAccount);
     }
 

--- a/community/src/test/java/efub/assignment/community/account/repository/AccountRepositoryTest.java
+++ b/community/src/test/java/efub/assignment/community/account/repository/AccountRepositoryTest.java
@@ -1,0 +1,98 @@
+package efub.assignment.community.account.repository;
+
+import efub.assignment.community.account.domain.Account;
+import efub.assignment.community.account.dto.SignUpRequestDto;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE, connection = EmbeddedDatabaseConnection.H2)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AccountRepositoryTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    private Account testAccount;
+
+    @BeforeEach
+    void testAccount_persist_setUp() {
+        // 테스트를 위한 Account 인스턴스 생성
+        String email = "email@domain.com";
+        String password = "password";
+        String nickname = "사용자명";
+        String university = "Test Univ.";
+        String studentId = "1234";
+
+        SignUpRequestDto requestDto = new SignUpRequestDto(email, password, nickname, university, studentId);
+        testAccount = requestDto.toEntity();
+        testEntityManager.persist(testAccount);
+    }
+
+    @Test
+    void save_test() {
+        // when
+        Account foundAccount = testEntityManager.find(Account.class, testAccount.getAccountId());
+        // then
+        assertEquals(testAccount, foundAccount);
+    }
+
+    @Test
+    void existsByEmail_test() {
+        // when
+        Boolean isExisting = accountRepository.existsByEmail("email@domain.com");
+        // then
+        assertTrue(isExisting);
+    }
+
+    @Test
+    void existsByNickname_test() {
+        // when
+        Boolean isExisting = accountRepository.existsByNickname("사용자명");
+        // then
+        assertTrue(isExisting);
+    }
+
+    @Test
+    void findById_test() {
+        // when
+        Optional<Account> accountOptional = accountRepository.findById(testAccount.getAccountId());
+        Account foundAccount = accountOptional.get();
+        // then
+        assertNotNull(accountOptional);
+        assertEquals(testAccount, foundAccount);
+    }
+
+    @Test
+    void findByEmail_test() {
+        // when
+        Optional<Account> accountOptional = accountRepository.findByEmail(testAccount.getEmail());
+        Account foundAccount = accountOptional.get();
+        // then
+        assertNotNull(accountOptional);
+        assertThat(testAccount).isEqualTo(foundAccount); // assertJ의 assertion을 사용
+    }
+
+    @Test
+    void findByNickname_test() {
+        // when
+        Optional<Account> accountOptional = accountRepository.findByNickname("사용자명");
+        Account foundAccount = accountOptional.get();
+        // then
+        assertNotNull(accountOptional);
+        assertThat(testAccount).isEqualTo(foundAccount);
+    }
+
+}

--- a/community/src/test/java/efub/assignment/community/account/repository/AccountRepositoryTest.java
+++ b/community/src/test/java/efub/assignment/community/account/repository/AccountRepositoryTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE, connection = EmbeddedDatabaseConnection.H2)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 class AccountRepositoryTest {
 
     @Autowired

--- a/community/src/test/java/efub/assignment/community/account/repository/AccountRepositoryTest.java
+++ b/community/src/test/java/efub/assignment/community/account/repository/AccountRepositoryTest.java
@@ -1,7 +1,6 @@
 package efub.assignment.community.account.repository;
 
 import efub.assignment.community.account.domain.Account;
-import efub.assignment.community.account.dto.SignUpRequestDto;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;

--- a/community/src/test/java/efub/assignment/community/post/domain/PostTest.java
+++ b/community/src/test/java/efub/assignment/community/post/domain/PostTest.java
@@ -1,12 +1,8 @@
 package efub.assignment.community.post.domain;
 
 import efub.assignment.community.account.domain.Account;
-import efub.assignment.community.account.dto.SignUpRequestDto;
-import efub.assignment.community.account.repository.AccountRepository;
 import efub.assignment.community.board.domain.Board;
-import efub.assignment.community.post.dto.PostUpdateDto;
 import org.junit.jupiter.api.*;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/community/src/test/java/efub/assignment/community/post/domain/PostTest.java
+++ b/community/src/test/java/efub/assignment/community/post/domain/PostTest.java
@@ -1,0 +1,45 @@
+package efub.assignment.community.post.domain;
+
+import efub.assignment.community.account.domain.Account;
+import efub.assignment.community.account.dto.SignUpRequestDto;
+import efub.assignment.community.account.repository.AccountRepository;
+import efub.assignment.community.board.domain.Board;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class PostTest {
+
+    private Account testAccount;
+    private Board testBoard;
+
+    @BeforeEach
+    void testAccount_persist_setUp() {
+        // 테스트를 위한 Account 인스턴스 생성
+        String email = "email@domain.com";
+        String password = "password";
+        String nickname = "사용자명";
+        String university = "Test Univ.";
+        String studentId = "1234";
+
+        Account account = Account.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .university(university)
+                .studentId(studentId)
+                .build();
+        testAccount = account;
+    }
+
+    @Order(1)
+    @Test
+    void post_build_test() {
+        // given
+    }
+}

--- a/community/src/test/java/efub/assignment/community/post/domain/PostTest.java
+++ b/community/src/test/java/efub/assignment/community/post/domain/PostTest.java
@@ -4,6 +4,7 @@ import efub.assignment.community.account.domain.Account;
 import efub.assignment.community.account.dto.SignUpRequestDto;
 import efub.assignment.community.account.repository.AccountRepository;
 import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.post.dto.PostUpdateDto;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -27,19 +28,81 @@ class PostTest {
         String university = "Test Univ.";
         String studentId = "1234";
 
-        Account account = Account.builder()
+        testAccount = Account.builder()
                 .email(email)
                 .password(password)
                 .nickname(nickname)
                 .university(university)
                 .studentId(studentId)
                 .build();
-        testAccount = account;
+    }
+
+    @BeforeEach
+    void testBoard_persist_setUp() {
+        // 테스트를 위한 Board 인스턴스 생성
+        String boardName = "보드이름";
+        String boardDescription = "보드설명";
+        String boardNotice = "보드공지";
+
+        testBoard = Board.builder()
+                .account(testAccount)
+                .boardName(boardName)
+                .boardDescription(boardDescription)
+                .boardNotice(boardNotice)
+                .build();
     }
 
     @Order(1)
     @Test
     void post_build_test() {
         // given
+        String title = "제목";
+        String content = "내용";
+        String writerOpen = "PUBLIC";
+
+        // when
+        Post post = Post.builder()
+                .account(testAccount)
+                .board(testBoard)
+                .title(title)
+                .content(content)
+                .writerOpen(writerOpen)
+                .build();
+
+        // then
+        assertEquals(testAccount, post.getAccount());
+        assertEquals(testBoard, post.getBoard());
+        assertEquals(title, post.getTitle());
+        assertEquals(content, post.getContent());
+        assertEquals(writerOpen, post.getWriterOpen());
+    }
+
+    @Order(2)
+    @Test
+    void post_update_test() {
+        // given
+        String title = "제목";
+        String content = "내용";
+        String writerOpen = "PUBLIC";
+
+        Post post = Post.builder()
+                .account(testAccount)
+                .board(testBoard)
+                .title(title)
+                .content(content)
+                .writerOpen(writerOpen)
+                .build();
+
+        String newTitle = "새 제목";
+        String newContent = "새 내용";
+        String newWriterOpen = "PRIVATE";
+
+        // when
+        post.update(newTitle, newContent, newWriterOpen);
+
+        // then
+        assertEquals(newTitle, post.getTitle());
+        assertEquals(newContent, post.getContent());
+        assertEquals(newWriterOpen, post.getWriterOpen());
     }
 }

--- a/community/src/test/java/efub/assignment/community/post/repository/PostRepositoryTest.java
+++ b/community/src/test/java/efub/assignment/community/post/repository/PostRepositoryTest.java
@@ -1,13 +1,88 @@
 package efub.assignment.community.post.repository;
 
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.TestMethodOrder;
+import efub.assignment.community.account.domain.Account;
+import efub.assignment.community.account.repository.AccountRepository;
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.post.domain.Post;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE, connection = EmbeddedDatabaseConnection.H2)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class PostRepositoryTest {
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    private Account testAccount;
+    private Board testBoard;
+    private Post testPost;
+
+
+    @BeforeEach
+    void post_persist_setUp() {
+        // given
+        // 테스트를 위한 인스턴스 생성
+        testAccount = Account.builder()
+                .email("email@domain.com")
+                .password("password")
+                .nickname("사용자명")
+                .university("Test Univ.")
+                .studentId("1234")
+                .build();
+        testEntityManager.persist(testAccount);
+
+        testBoard = Board.builder()
+                .account(testAccount)
+                .boardName("보드이름")
+                .boardDescription("보드설명")
+                .boardNotice("보드공지")
+                .build();
+        testEntityManager.persist(testBoard);
+
+        String title = "제목";
+        String content = "내용";
+        String writerOpen = "PUBLIC";
+
+        // when
+        testPost = Post.builder()
+                .account(testAccount)
+                .board(testBoard)
+                .title(title)
+                .content(content)
+                .writerOpen(writerOpen)
+                .build();
+        testEntityManager.persist(testPost);
+    }
+
+    @Test
+    void save_test() {
+        // when
+        Post foundPost = testEntityManager.find(Post.class, testPost.getPostId());
+        // then
+        assertEquals(testPost, foundPost);
+    }
+
+    @Test
+    void findById_test() {
+        // when
+        Optional<Post> postOptional = postRepository.findById(testPost.getPostId());
+        Post foundPost = postOptional.get();
+        // then
+        assertNotNull(postOptional);
+        assertEquals(testPost, foundPost);
+    }
 }

--- a/community/src/test/java/efub/assignment/community/post/repository/PostRepositoryTest.java
+++ b/community/src/test/java/efub/assignment/community/post/repository/PostRepositoryTest.java
@@ -1,7 +1,6 @@
 package efub.assignment.community.post.repository;
 
 import efub.assignment.community.account.domain.Account;
-import efub.assignment.community.account.repository.AccountRepository;
 import efub.assignment.community.board.domain.Board;
 import efub.assignment.community.post.domain.Post;
 import org.junit.jupiter.api.*;

--- a/community/src/test/java/efub/assignment/community/post/repository/PostRepositoryTest.java
+++ b/community/src/test/java/efub/assignment/community/post/repository/PostRepositoryTest.java
@@ -1,0 +1,13 @@
+package efub.assignment.community.post.repository;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class PostRepositoryTest {
+}


### PR DESCRIPTION
# 구현 기능
- Member, Post의 엔티티, 레포지토리 테스트 코드를 작성했습니다.
- 서비스 코드 일부 사항에 대해 리팩토링을 진행했습니다.
- 세션 블로그 정리: https://hereishyun.tistory.com/175

# 과제 정리
1. AccountTest
2. AccountRepositoryTest
3. PostTest
4. PostRepositoryTest
- 결과 사진:
![image](https://github.com/user-attachments/assets/f4a31840-7691-4791-823a-fc42bcc6ad32)
- 자료조사 중 JUnit의 `assertEquals(... , ...)` 외에, assertJ에서 `assertThat(...).isEqualTo(...)`을 제공하고 있으며 가독성 차원에서 후자를 선호하는 경우가 많음을 알게 되었다.

# 어려웠던 점(생략 가능)
- 해당 단위 테스트 수준 밖으로 필요한 인스턴스들(연관관계 엔티티, 레포지토리 테스트에서 엔티티)을 `@BeforeEach`로 생성해 놓고 재활용하였는데 이것이 좋은 방법이 맞는지 고민되었다.
- 제약 조건까지 검사해야 하는 게 필요한 것인지 고민하였다.