### PR TITLE
[정유정] 12주차 과제 제출 

### DIFF
--- a/community/build.gradle
+++ b/community/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/community/src/main/java/efub/assignment/community/post/PostRepository.java
+++ b/community/src/main/java/efub/assignment/community/post/PostRepository.java
@@ -3,7 +3,9 @@ package efub.assignment.community.post;
 import efub.assignment.community.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<Post,Long> {
+import java.util.List;
 
+public interface PostRepository extends JpaRepository<Post,Long> {
+    List<Post> findByWriterOpen(Boolean writerOpen);
 
 }

--- a/community/src/main/java/efub/assignment/community/post/controller/PostController.java
+++ b/community/src/main/java/efub/assignment/community/post/controller/PostController.java
@@ -62,7 +62,7 @@ public class PostController {
         return PostResponseDto.from(post, post.getAccount().getNickname(), post.getBoard().getBoardId());
     }
 
-    @PutMapping("/posts/{post_id}")
+    @PatchMapping("/posts/{post_id}")
     @ResponseStatus(value = HttpStatus.OK)
     public PostResponseDto updatePost(@PathVariable(name="post_id")Long post_id,
                                       @RequestBody @Valid PostUpdateDto dto){

--- a/community/src/main/java/efub/assignment/community/post/domain/Post.java
+++ b/community/src/main/java/efub/assignment/community/post/domain/Post.java
@@ -39,8 +39,8 @@ public class Post extends BaseTimeEntity {
     @Column(nullable = false, length = 1000)
     private String content;
 
-    @Column(nullable = false, length = 10)
-    private String writerOpen;
+    @Column(nullable = false)
+    private Boolean writerOpen;
 
     /* mappedBy : 연관관계의 주인 */
     /* cascade : 엔티티 삭제 시 연관된 엔티티의 처리 방식 */
@@ -55,7 +55,7 @@ public class Post extends BaseTimeEntity {
     private List<PostHeart> postHeartList = new ArrayList<>();
 
     @Builder
-    public Post(Account account, Board board, String title, String content, String writerOpen){
+    public Post(Account account, Board board, String title, String content, Boolean writerOpen){
         this.account = account;
         this.board = board;
         this.title = title;
@@ -66,5 +66,6 @@ public class Post extends BaseTimeEntity {
     public void update(PostUpdateDto dto){
         this.title = dto.getTitle();
         this.content = dto.getContent();
+        this.writerOpen = dto.getWriterOpen();
     }
 }

--- a/community/src/main/java/efub/assignment/community/post/dto/PostRequestDto.java
+++ b/community/src/main/java/efub/assignment/community/post/dto/PostRequestDto.java
@@ -24,8 +24,8 @@ public class PostRequestDto {
     @NotBlank(message = "내용은 필수입니다.")
     private String content;
 
-    @Value("${writer.open:false}")
-    private String writerOpen;
+    @NotBlank
+    private Boolean writerOpen;
 
     public Post toEntity(Board board, Account account){
         return Post.builder()

--- a/community/src/main/java/efub/assignment/community/post/dto/PostResponseDto.java
+++ b/community/src/main/java/efub/assignment/community/post/dto/PostResponseDto.java
@@ -17,7 +17,7 @@ public class PostResponseDto {
     private String writerNickname;
     private String title;
     private String content;
-    private String writerOpen;
+    private Boolean writerOpen;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
 

--- a/community/src/main/java/efub/assignment/community/post/dto/PostUpdateDto.java
+++ b/community/src/main/java/efub/assignment/community/post/dto/PostUpdateDto.java
@@ -13,9 +13,14 @@ public class PostUpdateDto {
     @NotBlank(message = "글의 내용은 필수입니다.")
     private String content;
 
+    @NotBlank
+    private Boolean writerOpen;
+
+    @NotBlank(message = "글의 익명여부는 필수입니다.")
     @Builder
-    public PostUpdateDto(String title, String content){
+    public PostUpdateDto(String title, String content, Boolean writerOpen){
         this.title = title;
         this.content = content;
+        this.writerOpen = writerOpen;
     }
 }

--- a/community/src/test/java/efub/assignment/community/account/AccountRepositoryTest.java
+++ b/community/src/test/java/efub/assignment/community/account/AccountRepositoryTest.java
@@ -1,0 +1,64 @@
+package efub.assignment.community.account;
+
+import efub.assignment.community.account.domain.Account;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class AccountRepositoryTest {
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Test
+    @DisplayName("이메일 중복 확인 - 성공")
+    void validateEmail() {
+        // given
+        Account account = Account.builder()
+                .email("test@test.com")
+                .password("password123")
+                .nickname("fubie")
+                .university("이화여자대학교")
+                .studentId("1234567")
+                .build();
+        accountRepository.save(account);
+
+        // when
+        Boolean exists = accountRepository.existsByEmail("test@test.com");
+
+        // then
+        assertTrue(exists, "이메일이 존재합니다.");
+    }
+
+    @Test
+    @DisplayName("닉네임으로 계정 조회 - 실패")
+    void findByNickname() {
+        // given
+        Account account = Account.builder()
+                .email("test@test.com")
+                .password("password123")
+                .nickname("fubie")
+                .university("이화여자대학교")
+                .studentId("1234567")
+                .build();
+        accountRepository.save(account);
+        String searchNickname = "iamfubie";
+
+        // when
+        Optional<Account> searchAccount = accountRepository.findByNickname(searchNickname);
+
+        // then
+        assertFalse(searchAccount.isPresent(), "존재하지 않는 닉네임입니다.");
+    }
+
+
+}

--- a/community/src/test/java/efub/assignment/community/account/AccountRepositoryTest.java
+++ b/community/src/test/java/efub/assignment/community/account/AccountRepositoryTest.java
@@ -4,6 +4,7 @@ import efub.assignment.community.account.domain.Account;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -13,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
 class AccountRepositoryTest {
 

--- a/community/src/test/java/efub/assignment/community/account/domain/AccountTest.java
+++ b/community/src/test/java/efub/assignment/community/account/domain/AccountTest.java
@@ -2,9 +2,15 @@ package efub.assignment.community.account.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 class AccountTest {
 
     @Test

--- a/community/src/test/java/efub/assignment/community/account/domain/AccountTest.java
+++ b/community/src/test/java/efub/assignment/community/account/domain/AccountTest.java
@@ -1,0 +1,59 @@
+package efub.assignment.community.account.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AccountTest {
+
+    @Test
+    @DisplayName("Account 생성 - 성공")
+    void createAccount() {
+        // given
+        String email = "test@test.com";
+        String password = "password123";
+        String nickname = "fubie";
+        String university = "이화여자대학교";
+        String studentId = "1234567";
+
+        // when
+        Account account = Account.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .university(university)
+                .studentId(studentId)
+                .build();
+
+        // then
+        assertAll("Account 필드 값 검증",
+                () -> assertEquals(email, account.getEmail()),
+                () -> assertEquals(password, account.getPassword()),
+                () -> assertEquals(nickname, account.getNickname()),
+                () -> assertEquals(university, account.getUniversity()),
+                () -> assertEquals(studentId, account.getStudentId()),
+                () -> assertEquals(AccountStatus.REGISTERED, account.getStatus())
+        );
+    }
+
+    @Test
+    @DisplayName("비어 있는 닉네임으로 업데이트 - 실패")
+    void updateAccount(){
+        // given
+        Account account = Account.builder()
+                .email("test@test.com")
+                .password("password123")
+                .nickname("fubie")
+                .university("이화여자대학교")
+                .studentId("1234567")
+                .build();
+
+        // when
+        String newNickname = "";
+
+        // then
+        assertTrue(newNickname.isEmpty(), "닉네임은 비어 있을 수 없습니다.");
+    }
+
+}

--- a/community/src/test/java/efub/assignment/community/post/PostRepositoryTest.java
+++ b/community/src/test/java/efub/assignment/community/post/PostRepositoryTest.java
@@ -1,0 +1,116 @@
+package efub.assignment.community.post;
+
+import efub.assignment.community.account.AccountRepository;
+import efub.assignment.community.account.domain.Account;
+import efub.assignment.community.board.BoardRepository;
+import efub.assignment.community.board.domain.Board;
+import efub.assignment.community.post.domain.Post;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class PostRepositoryTest {
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    private Account account;
+    private Board board;
+
+    @BeforeEach
+    void setup() {
+        account = Account.builder()
+                .email("test@test.com")
+                .password("password123")
+                .nickname("fubie")
+                .university("이화여자대학교")
+                .studentId("1234567")
+                .build();
+        accountRepository.save(account);
+
+        board = Board.builder()
+                .account(account)
+                .boardName("테스트 게시판")
+                .boardDescription("테스트 설명")
+                .boardNotice("테스트 공지사항")
+                .build();
+        boardRepository.save(board);
+    }
+
+    @Test
+    @DisplayName("writerOpen이 true인 Post 조회 - 성공")
+    void findOpenPostsSuccessfully() {
+        // given
+        String title1 = "공개 게시글";
+        String content1 = "이건 보여야 함";
+        Boolean writerOpen1 = true;
+
+        String title2 = "비공개 게시글";
+        String content2 = "이건 안 보여야 함";
+        Boolean writerOpen2 = false;
+
+        Post publicPost = Post.builder()
+                .account(account)
+                .board(board)
+                .title(title1)
+                .content(content1)
+                .writerOpen(writerOpen1)
+                .build();
+        postRepository.save(publicPost);
+
+        Post privatePost = Post.builder()
+                .account(account)
+                .board(board)
+                .title(title2)
+                .content(content2)
+                .writerOpen(writerOpen2)
+                .build();
+        postRepository.save(privatePost);
+
+        // when
+        List<Post> openPosts = postRepository.findByWriterOpen(true);
+
+        // then
+        assertEquals(1, openPosts.size(), "writerOpen이 true인 게시글이 하나여야 합니다.");
+        assertEquals(title1, openPosts.get(0).getTitle(), "조회된 게시글의 제목이 일치해야 합니다.");
+    }
+
+
+    @Test
+    @DisplayName("Post 조회 실패 - 존재하지 않는 ID")
+    void findPostByDeletedId() {
+        // given
+        Post post = Post.builder()
+                .account(account)
+                .board(board)
+                .title("제목")
+                .content("내용")
+                .writerOpen(true)
+                .build();
+        postRepository.save(post);
+        Long deletedId = post.getPostId();
+        postRepository.delete(post);
+
+        // when
+        Optional<Post> searchPost = postRepository.findById(deletedId);
+
+        // then
+        assertFalse(searchPost.isPresent(), "존재하지 않는 ID로 Post를 조회할 수 없습니다. ");
+    }
+
+}

--- a/community/src/test/java/efub/assignment/community/post/domain/PostTest.java
+++ b/community/src/test/java/efub/assignment/community/post/domain/PostTest.java
@@ -2,43 +2,47 @@ package efub.assignment.community.post.domain;
 
 import efub.assignment.community.account.domain.Account;
 import efub.assignment.community.board.domain.Board;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
 class PostTest {
 
     @Autowired
-    private EntityManager entityManager;
+    private TestEntityManager testEntityManager;
 
     private Account account;
     private Board board;
 
     @BeforeEach
     void setup(){
-        Account account = Account.builder()
+        account = Account.builder()
                 .email("test@test.com")
                 .password("password123")
                 .nickname("fubie")
                 .university("이화여자대학교")
                 .studentId("1234567")
                 .build();
-        entityManager.persist(account);
+        testEntityManager.persist(account);
         board = Board.builder()
                 .account(account)
                 .boardName("테스트 게시판")
                 .boardDescription("테스트 설명")
                 .boardNotice("테스트 공지사항")
                 .build();
-        entityManager.persist(board);
+        testEntityManager.persist(board);
+        testEntityManager.flush();
     }
 
     @Test
@@ -57,8 +61,8 @@ class PostTest {
                 .content(content)
                 .writerOpen(writerOpen)
                 .build();
-
-        entityManager.persist(post);
+        testEntityManager.persist(post);
+        testEntityManager.flush();
 
         // then
         assertAll("Post 필드 값 검증",
@@ -88,8 +92,8 @@ class PostTest {
                     .content(content)
                     .writerOpen(writerOpen)
                     .build();
-            entityManager.persist(post);
-            entityManager.flush();
+            testEntityManager.persist(post);
+            testEntityManager.flush();
         });
     }
 

--- a/community/src/test/java/efub/assignment/community/post/domain/PostTest.java
+++ b/community/src/test/java/efub/assignment/community/post/domain/PostTest.java
@@ -1,0 +1,76 @@
+package efub.assignment.community.post.domain;
+
+import efub.assignment.community.account.domain.Account;
+import efub.assignment.community.board.domain.Board;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class PostTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Account account;
+    private Board board;
+
+    @BeforeEach
+    void setup(){
+        Account account = Account.builder()
+                .email("test@test.com")
+                .password("password123")
+                .nickname("fubie")
+                .university("이화여자대학교")
+                .studentId("1234567")
+                .build();
+        entityManager.persist(account);
+        board = Board.builder()
+                .account(account)
+                .boardName("테스트 게시판")
+                .boardDescription("테스트 설명")
+                .boardNotice("테스트 공지사항")
+                .build();
+        entityManager.persist(board);
+    }
+
+    @Test
+    @DisplayName("Post 생성 - 성공")
+    void createPost() {
+        // given
+        String title = "제목제목";
+        String content = "내용내용";
+        Boolean writerOpen = true;
+
+        // when
+        Post post = Post.builder()
+                .account(account)
+                .board(board)
+                .title(title)
+                .content(content)
+                .writerOpen(writerOpen)
+                .build();
+
+        entityManager.persist(post);
+
+        // then
+        assertAll("Post 필드 값 검증",
+                () -> assertNotNull(post.getPostId()),
+                () -> assertEquals(title, post.getTitle()),
+                () -> assertEquals(content, post.getContent()),
+                () -> assertEquals(writerOpen, post.getWriterOpen()),
+                () -> assertEquals(account, post.getAccount()),
+                () -> assertEquals(board, post.getBoard())
+        );
+
+    }
+
+
+}

--- a/community/src/test/java/efub/assignment/community/post/domain/PostTest.java
+++ b/community/src/test/java/efub/assignment/community/post/domain/PostTest.java
@@ -69,8 +69,30 @@ class PostTest {
                 () -> assertEquals(account, post.getAccount()),
                 () -> assertEquals(board, post.getBoard())
         );
-
     }
+
+    @Test
+    @DisplayName("Post 생성 실패 - 제목 글자 수 초과")
+    void createPostWithLongTitle() {
+        // given
+        String longTitle = "제목".repeat(30);
+        String content = "내용내용";
+        Boolean writerOpen = true;
+
+        // when & then
+        assertThrows(Exception.class, () -> {
+            Post post = Post.builder()
+                    .account(account)
+                    .board(board)
+                    .title(longTitle)
+                    .content(content)
+                    .writerOpen(writerOpen)
+                    .build();
+            entityManager.persist(post);
+            entityManager.flush();
+        });
+    }
+
 
 
 }


### PR DESCRIPTION
# 구현 기능
- account, post 엔티티&레포지토리 테스트 코드 작성
- post의 writeOpen필드 Boolean으로 수정

# 과제 정리
- account 엔티티: Account 생성 - 성공, 비어 있는 닉네임으로 업데이트 - 실패 테스트 케이스 작성
![image](https://github.com/user-attachments/assets/2f2b1798-7dd4-47b4-b3f1-85dc5f90085c)
- account 레포지토리: 이메일 중복 확인 - 성공, 닉네임으로 계정 조회 - 실패 테스트 케이스 작성
![image](https://github.com/user-attachments/assets/26443ca4-dc0c-45cd-8d64-dc46e6d85cf4)
- post 엔티티: Post 생성 - 성공, Post 생성 실패 - 제목 글자 수 초과 테스트 케이스 작성
![image](https://github.com/user-attachments/assets/727acb75-e26d-4200-9a79-f8377a614a3f)
- post 레포지토리: writerOpen이 true인 Post 조회 - 성공, Post 조회 실패 - 존재하지 않는 ID 테스트 케이스 작성
![image](https://github.com/user-attachments/assets/0f819e08-cbfe-4a02-9a02-d744c5ca71fc)

# 어려웠던 점(생략 가능) 
데이터베이스 환경 문제를 겪었습니다. replace.ANY 속성으로 설정되어 있어 MySQL 모드 데이터베이스(application-test.yml의 url: jdbc:h2:mem:testdb;MODE=MySQL) 를 사용할 수 없었습니다. replace.NONE으로 수정했습니다.