### PR TITLE
[황채린] 13주차 과제 제출

### DIFF
--- a/community/build.gradle
+++ b/community/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/community/src/main/java/efub/assignment/community/exception/RestExceptionAdvice.java
+++ b/community/src/main/java/efub/assignment/community/exception/RestExceptionAdvice.java
@@ -35,6 +35,7 @@ public class RestExceptionAdvice {
     }
 
     @ExceptionHandler({EntityNotFoundException.class})
+    @ResponseStatus(HttpStatus.NOT_FOUND)
     protected HttpErrorResponse handleEntityNotFoundException(EntityNotFoundException ex, HttpServletRequest request){
         return HttpErrorResponse.builder()
                 .status(HttpStatus.BAD_REQUEST.value())
@@ -45,6 +46,7 @@ public class RestExceptionAdvice {
     }
 
     @ExceptionHandler({EntityExistsException.class})
+    @ResponseStatus(HttpStatus.CONFLICT)
     protected HttpErrorResponse handleEntityExistsException(EntityExistsException ex, HttpServletRequest request){
         return HttpErrorResponse.builder()
                 .status(HttpStatus.BAD_REQUEST.value())

--- a/community/src/test/java/efub/assignment/community/member/controller/MemberControllerTest.java
+++ b/community/src/test/java/efub/assignment/community/member/controller/MemberControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -34,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Sql(scripts = "/data.sql")
+@Sql(scripts = "/data.sql", executionPhase = ExecutionPhase.BEFORE_TEST_CLASS)
 @ActiveProfiles("test")
 @ContextConfiguration(classes = CommunityApplication.class)
 @TestPropertySource(locations = "classpath:application-test.yml")

--- a/community/src/test/java/efub/assignment/community/member/controller/MemberControllerTest.java
+++ b/community/src/test/java/efub/assignment/community/member/controller/MemberControllerTest.java
@@ -1,0 +1,271 @@
+package efub.assignment.community.member.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import efub.assignment.community.CommunityApplication;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.dto.MemberRequestDto;
+import efub.assignment.community.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Sql(scripts = "/data.sql")
+@ActiveProfiles("test")
+@ContextConfiguration(classes = CommunityApplication.class)
+@TestPropertySource(locations = "classpath:application-test.yml")
+class MemberControllerTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected WebApplicationContext context;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected MemberRepository memberRepository;
+
+    @BeforeEach
+    public void setMockMvc() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+            .build();
+    }
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void signUp_success() throws Exception {
+
+        //given
+        final String url = "/members";
+        final String email = "hi@test.com";
+        final String password = "password";
+        final String nickname = "nickname";
+        final String university = "university";
+        final String studentId = "1234";
+        final MemberRequestDto requestDto = MemberRequestDto.builder()
+            .email(email)
+            .password(password)
+            .nickname(nickname)
+            .university(university)
+            .studentId(studentId)
+            .build();
+
+        //when
+        final String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        ResultActions resultActions = mockMvc.perform(post(url)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody));
+
+        //then
+        resultActions
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.memberId").isNotEmpty())
+            .andExpect(jsonPath("$.email").value(email))
+            .andExpect(jsonPath("$.nickname").value(nickname))
+            .andExpect(jsonPath("$.university").value(university))
+            .andExpect(jsonPath("$.studentId").value(studentId));
+    }
+
+    @Test
+    @DisplayName("이미 가입된 이메일로 회원가입 시 실패")
+    void signUp_fail() throws Exception {
+
+        //given
+        final String url = "/members";
+        final String email = "test1@test.com";
+        final String password = "password";
+        final String nickname = "nickname";
+        final String university = "university";
+        final String studentId = "1234";
+        final MemberRequestDto requestDto = MemberRequestDto.builder()
+            .email(email)
+            .password(password)
+            .nickname(nickname)
+            .university(university)
+            .studentId(studentId)
+            .build();
+
+        //when
+        final String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        ResultActions resultActions = mockMvc.perform(post(url)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody));
+
+        //then
+        resultActions
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.memberId").isNotEmpty())
+            .andExpect(jsonPath("$.email").value(email))
+            .andExpect(jsonPath("$.nickname").value(nickname))
+            .andExpect(jsonPath("$.university").value(university))
+            .andExpect(jsonPath("$.studentId").value(studentId));
+    }
+
+    @Test
+    @DisplayName("멤버 조회 성공")
+    void getMember_success() throws Exception {
+
+        //given
+        final Long memberId = 1L;
+        final String url = "/members/{memberId}";
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get(url, memberId));
+        Member member = memberRepository.findById(memberId).get();
+
+        //then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.memberId").value(memberId))
+            .andExpect(jsonPath("$.email").value(member.getEmail()))
+            .andExpect(jsonPath("$.nickname").value(member.getNickname()))
+            .andExpect(jsonPath("$.university").value(member.getUniversity()))
+            .andExpect(jsonPath("$.studentId").value(member.getStudentId()));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 ID로 멤버 조회 시 실패")
+    void getMember_fail() throws Exception {
+
+        //given
+        final Long memberId = 3L;
+        final String url = "/members/{memberId}";
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get(url, memberId));
+
+        //then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.memberId").value(memberId));
+    }
+
+    @Test
+    @DisplayName("멤버 수정 성공")
+    void updateMember_success() throws Exception {
+
+        //given
+        final Long memberId = 1L;
+        final String url = "/members/profile/{memberId}";
+        final String email = "test1@test.com";
+        final String password = "password";
+        final String nickname = "new nickname";
+        final String university = "university";
+        final String studentId = "1234";
+        final MemberRequestDto requestDto = MemberRequestDto.builder()
+            .email(email)
+            .password(password)
+            .nickname(nickname)
+            .university(university)
+            .studentId(studentId)
+            .build();
+
+        //when
+        final String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        ResultActions resultActions = mockMvc.perform(patch(url, memberId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody));
+
+        //then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.nickname").value(nickname));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 닉네임으로 멤버 수정 시 실패")
+    void updateMember_fail() throws Exception {
+
+        //given
+        final Long memberId = 1L;
+        final String url = "/members/profile/{memberId}";
+        final String email = "test1@test.com";
+        final String password = "password";
+        final String nickname = "test2";
+        final String university = "university";
+        final String studentId = "1234";
+        final MemberRequestDto requestDto = MemberRequestDto.builder()
+            .email(email)
+            .password(password)
+            .nickname(nickname)
+            .university(university)
+            .studentId(studentId)
+            .build();
+
+        //when
+        final String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        ResultActions resultActions = mockMvc.perform(patch(url, memberId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody));
+
+        //then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.nickname").value(nickname));
+    }
+
+    @Test
+    @DisplayName("멤버 탈퇴 성공")
+    void withdraw_success() throws Exception {
+
+        //given
+        final Long memberId = 1L;
+        final String url = "/members/{memberId}";
+
+        //when
+        ResultActions resultActions = mockMvc.perform(patch(url, memberId));
+
+        //then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(content().string("삭제가 완료되었습니다."));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 ID로 멤버 탈퇴 시 실패")
+    void withdraw_fail() throws Exception {
+
+        //given
+        final Long memberId = 333L;
+        final String url = "/members/{memberId}";
+
+        //when
+        ResultActions resultActions = mockMvc.perform(patch(url, memberId));
+
+        //then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(content().string("삭제가 완료되었습니다."));
+    }
+}

--- a/community/src/test/java/efub/assignment/community/post/controller/PostControllerTest.java
+++ b/community/src/test/java/efub/assignment/community/post/controller/PostControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -33,7 +34,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Sql(scripts = "/data.sql")
+@Sql(scripts = "/data.sql", executionPhase = ExecutionPhase.BEFORE_TEST_CLASS)
 @ActiveProfiles("test")
 @ContextConfiguration(classes = CommunityApplication.class)
 @TestPropertySource(locations = "classpath:application-test.yml")
@@ -237,7 +238,7 @@ class PostControllerTest {
     void deletePost_success() throws Exception {
 
         //given
-        final Long postId = 1L;
+        final Long postId = 3L;
         final String url = "/posts/{postId}";
 
         //when

--- a/community/src/test/java/efub/assignment/community/post/controller/PostControllerTest.java
+++ b/community/src/test/java/efub/assignment/community/post/controller/PostControllerTest.java
@@ -1,0 +1,268 @@
+package efub.assignment.community.post.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import efub.assignment.community.CommunityApplication;
+import efub.assignment.community.member.repository.MemberRepository;
+import efub.assignment.community.post.dto.PostCreateRequestDto;
+import efub.assignment.community.post.dto.PostUpdateRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Sql(scripts = "/data.sql")
+@ActiveProfiles("test")
+@ContextConfiguration(classes = CommunityApplication.class)
+@TestPropertySource(locations = "classpath:application-test.yml")
+class PostControllerTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected WebApplicationContext context;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected MemberRepository memberRepository;
+
+    @BeforeEach
+    public void setMockMvc() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+            .build();
+    }
+
+    @Test
+    @DisplayName("게시글 생성 성공")
+    void createPost_success() throws Exception {
+
+        //given
+        final String url = "/posts";
+        final Long boardId = 1L;
+        final String writerName = "test1";
+        final boolean anonymous = true;
+        final String content = "내용";
+        final PostCreateRequestDto requestDto = PostCreateRequestDto.builder()
+            .boardId(boardId)
+            .writerName(writerName)
+            .anonymous(anonymous)
+            .content(content)
+            .build();
+
+        //when
+        final String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        ResultActions resultActions = mockMvc.perform(post(url)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody));
+
+        //then
+        resultActions
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.boardId").value(boardId))
+            .andExpect(jsonPath("$.writerName").value(writerName))
+            .andExpect(jsonPath("$.anonymous").value(anonymous))
+            .andExpect(jsonPath("$.content").value(content));
+    }
+
+    @Test
+    @DisplayName("작성자의 닉네임이 DB에 존재하지 않을 경우 게시글 생성 실패")
+    void createPost_fail() throws Exception {
+
+        //given
+        final String url = "/posts";
+        final Long boardId = 1L;
+        final String writerName = "spy";
+        final boolean anonymous = true;
+        final String content = "내용";
+        final PostCreateRequestDto requestDto = PostCreateRequestDto.builder()
+            .boardId(boardId)
+            .writerName(writerName)
+            .anonymous(anonymous)
+            .content(content)
+            .build();
+
+        //when
+        final String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        ResultActions resultActions = mockMvc.perform(post(url)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody));
+
+        //then
+        resultActions
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.boardId").value(boardId))
+            .andExpect(jsonPath("$.writerName").value(writerName))
+            .andExpect(jsonPath("$.anonymous").value(anonymous))
+            .andExpect(jsonPath("$.content").value(content));
+    }
+
+    @Test
+    @DisplayName("게시글 수정 성공")
+    void updatePost_success() throws Exception {
+
+        //given
+        final Long postId = 1L;
+        final String url = "/posts/{postId}";
+        final String content = "new content";
+        final PostUpdateRequestDto requestDto = PostUpdateRequestDto.builder()
+            .content(content)
+            .build();
+
+        //when
+        final String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        ResultActions resultActions = mockMvc.perform(patch(url, postId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody));
+
+        //then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").value(content));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글 ID로 게시글 수정 시 실패")
+    void updatePost_fail() throws Exception {
+
+        //given
+        final Long postId = 1000L;
+        final String url = "/posts/{postId}";
+        final String content = "new content";
+        final PostUpdateRequestDto requestDto = PostUpdateRequestDto.builder()
+            .content(content)
+            .build();
+
+        //when
+        final String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        ResultActions resultActions = mockMvc.perform(patch(url, postId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody));
+
+        //then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").value(content));
+    }
+
+    @Test
+    @DisplayName("게시글 목록 조회 성공")
+    void getAllPosts_success() throws Exception {
+
+        //given
+        final Long boardId = 1L;
+        final String url = "/posts/list/{boardId}";
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get(url, boardId));
+
+        //then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.count").value(3));
+    }
+
+    @Test
+    @DisplayName("게시글 상세 조회 성공")
+    void getPost_success() throws Exception {
+
+        //given
+        final Long postId = 2L;
+        final String url = "/posts/{postId}";
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get(url, postId));
+
+        //then
+        resultActions
+            .andExpect(status().isOk())
+            //조회한 결과가 data.sql에서 저장한 데이터와 일치하는지 확인
+            .andExpect(jsonPath("$.boardId").value(1))
+            .andExpect(jsonPath("$.writerName").value("test2"))
+            .andExpect(jsonPath("$.anonymous").value(false))
+            .andExpect(jsonPath("$.content").value("노릇노릇"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글 ID로 게시글 상세 조회 시 실패")
+    void getPost_fail() throws Exception {
+
+        //given
+        final Long postId = 100L;
+        final String url = "/posts/{postId}";
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get(url, postId));
+
+        //then
+        resultActions
+            .andExpect(status().isOk())
+            //조회한 결과가 data.sql에서 저장한 데이터와 일치하는지 확인
+            .andExpect(jsonPath("$.boardId").value(1))
+            .andExpect(jsonPath("$.writerName").value("test2"))
+            .andExpect(jsonPath("$.anonymous").value(false))
+            .andExpect(jsonPath("$.content").value("노릇노릇"));
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 성공")
+    void deletePost_success() throws Exception {
+
+        //given
+        final Long postId = 1L;
+        final String url = "/posts/{postId}";
+
+        //when
+        ResultActions resultActions = mockMvc.perform(delete(url, postId));
+
+        //then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(content().string("게시글을 삭제했습니다."));
+    }
+    
+    @Test
+    @DisplayName("존재하지 않는 게시글 ID로 게시글 삭제 시 실패")
+    void deletePost_fail() throws Exception {
+
+        //given
+        final Long postId = 100L;
+        final String url = "/posts/{postId}";
+
+        //when
+        ResultActions resultActions = mockMvc.perform(delete(url, postId));
+
+        //then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(content().string("게시글을 삭제했습니다."));
+    }
+}

--- a/community/src/test/resources/application-test.yml
+++ b/community/src/test/resources/application-test.yml
@@ -1,0 +1,25 @@
+server:
+  port: 8080
+  servlet:
+    encoding:
+      charset: utf-8
+      force: true # 무슨일이 있어도 이렇게 인코딩하겠다
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL # h2의 문법을 mysql로 맞추겠다.
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      '[hibernate.default_batch_fetch_size]': 100
+      '[hibernate.format_sql]': true
+    show-sql: true
+    output:
+      ansi:
+        enabled: always

--- a/community/src/test/resources/data.sql
+++ b/community/src/test/resources/data.sql
@@ -12,3 +12,27 @@ INSERT INTO member(email,password,nickname,university,student_id,status) VALUES
     ('test1@test.com', 'testPW123', 'test1', 'testUni', '1234567', 'REGISTERED'),
     ('test2@test.com', 'testPW123', 'test2', 'testUni', '1234568', 'REGISTERED');
 
+CREATE TABLE IF NOT EXISTS board (
+                                     board_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                     member_id BIGINT,
+                                     name VARCHAR(20) NOT NULL,
+    description VARCHAR(100) NOT NULL,
+    notice VARCHAR(1000),
+    FOREIGN KEY (member_id) REFERENCES member(member_id) ON DELETE CASCADE
+    );
+INSERT INTO board(member_id, name, description) VALUES
+    (1,'testBoard', 'testDescription');
+
+CREATE TABLE IF NOT EXISTS post (
+                                    post_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                    board_id BIGINT,
+                                    member_id BIGINT,
+                                    is_anonymous TINYINT(1) NOT NULL,
+    content VARCHAR(1000),
+    FOREIGN KEY (board_id) REFERENCES board(board_id) ON DELETE CASCADE,
+    FOREIGN KEY (member_id) REFERENCES member(member_id) ON DELETE CASCADE
+    );
+INSERT INTO post(board_id, member_id, is_anonymous, content) VALUES
+    (1,2,1,'test'),
+    (1,2,0,'노릇노릇'),
+    (1,1,0,'한강');

--- a/community/src/test/resources/data.sql
+++ b/community/src/test/resources/data.sql
@@ -1,0 +1,14 @@
+
+CREATE TABLE IF NOT EXISTS member (
+    member_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(60) NOT NULL,
+    password VARCHAR NOT NULL,
+    nickname VARCHAR(20) NOT NULL,
+    university VARCHAR(20) NOT NULL,
+    student_id VARCHAR(10) NOT NULL,
+    status ENUM('REGISTERED', 'UNREGISTERED')
+);
+INSERT INTO member(email,password,nickname,university,student_id,status) VALUES
+    ('test1@test.com', 'testPW123', 'test1', 'testUni', '1234567', 'REGISTERED'),
+    ('test2@test.com', 'testPW123', 'test2', 'testUni', '1234568', 'REGISTERED');
+


### PR DESCRIPTION
# 구현 기능
- Member/Post 컨트롤러 테스트 코드 작성
- 예외 처리 코드 리팩토링

# 과제 정리
- Member 컨트롤러
     - 회원가입 성공/실패
     - 멤버 조회 성공/실패
     - 멤버 수정 성공/실패
     - 멤버 탈퇴 성공/실패
<img width="483" alt="image" src="https://github.com/user-attachments/assets/448f2be5-5c22-46e8-9c78-ca5597a7787c">

- Post 컨트롤러
     - 게시글 생성 성공/실패
     - 게시글 수정 성공/실패
     - 게시글 목록 조회 성공
     - 게시글 상세 조회 성공/실패
     - 게시글 삭제 성공/실패
<img width="491" alt="image" src="https://github.com/user-attachments/assets/769593bb-3881-4e17-8a66-1b800c496291">

# 어려웠던 점
테스트 메서드를 개별적으로 실행할 때는 의도했던대로 결과가 나왔으나, 테스트 클래스 단위로 실행 시 성공해야하는 테스트가 실패하는 현상 발생 → 에러 원인을 분석하니 Board 테이블의 name 필드에 unique 제약조건이 걸려있는 것과 관련됨 → 테스트 메서드가 실행되기 전마다 SQL 스크립트가 실행되는데,  중복 데이터가 존재하기 때문에 INSERT문에서 에러가 발생하는 거였음 → @Sql 어노테이션의 executionPhase 옵션을 통해 SQL 스크립트가 실행되는 시점을 BEFORE_TEST_CLASS 로 설정하여 해결 (DEFAULT 값은 BEFORE_TEST_METHOD) 
⇒ 위와 같이 해결할 경우 동일한 클래스 내에 존재하는 테스트끼리의 독립성은 보장되지 않기 때문에 완전한 해결이라고 볼 수 없을 것 같다. @BeforeEach 같은 어노테이션을 사용해 테스트 메서드가 실행되기 전마다 DB를 초기화시켜주는 작업이 필요할지 더 고민해봐야 할 것 같다. [ref](https://jjuunn.tistory.com/25)