### PR TITLE
[황채린] 16주차 과제 제출

### DIFF
--- a/community/build.gradle
+++ b/community/build.gradle
@@ -30,6 +30,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'com.h2database:h2'
+    /* Redis */
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    /* jwt */
+    implementation 'io.jsonwebtoken:jjwt:0.12.6' //자바 JWT 라이브러리
+    implementation 'javax.xml.bind:jaxb-api:2.3.1' //XML 문서와 Java 객체 간 매핑 자동화
+    /* OAuth2 */
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/community/src/main/java/efub/assignment/community/global/config/RedisConfig.java
+++ b/community/src/main/java/efub/assignment/community/global/config/RedisConfig.java
@@ -1,0 +1,46 @@
+package efub.assignment.community.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host,port);
+        config.setPassword(password);
+        return new LettuceConnectionFactory(config);
+    }
+
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(
+        RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+
+}

--- a/community/src/main/java/efub/assignment/community/global/config/SecurityConfig.java
+++ b/community/src/main/java/efub/assignment/community/global/config/SecurityConfig.java
@@ -1,0 +1,52 @@
+package efub.assignment.community.global.config;
+
+import efub.assignment.community.global.jwt.TokenProvider;
+import efub.assignment.community.global.oauth.OAuth2AuthenticationSuccessHandler;
+import efub.assignment.community.global.jwt.JwtAuthenticationFilter;
+import efub.assignment.community.global.oauth.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final TokenProvider tokenProvider;
+    private final CustomOAuth2UserService oAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    private static final String[] AUTH_WHITELIST = {
+        "/auth/token"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .csrf(AbstractHttpConfigurer::disable)
+            .cors(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(request -> {
+                request.requestMatchers(AUTH_WHITELIST).permitAll();
+                request.requestMatchers(HttpMethod.GET).permitAll();
+                request.anyRequest().authenticated();
+            })
+            .sessionManagement(
+                sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+            .addFilterBefore(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+            .oauth2Login(oauth2 -> oauth2
+                .userInfoEndpoint(userInfo -> userInfo.userService(oAuth2UserService))
+                .successHandler(oAuth2AuthenticationSuccessHandler))
+            .build();
+    }
+
+}

--- a/community/src/main/java/efub/assignment/community/global/jwt/JwtAuthenticationFilter.java
+++ b/community/src/main/java/efub/assignment/community/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,42 @@
+package efub.assignment.community.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final TokenProvider tokenProvider;
+
+    private static final String BEARER = "Bearer ";
+    private static final String HEADER = "Authorization";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+        String authorizationHeader = request.getHeader(HEADER);
+        String token = getAccessToken(authorizationHeader);
+        if(!ObjectUtils.isEmpty(token) && tokenProvider.validateToken(token)){
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request,response);
+    }
+
+    private String getAccessToken(String authorizationHeader) {
+        if(authorizationHeader != null && authorizationHeader.startsWith(BEARER)){
+            return authorizationHeader.substring(BEARER.length());
+        }
+        return null;
+    }
+
+}

--- a/community/src/main/java/efub/assignment/community/global/jwt/TokenProvider.java
+++ b/community/src/main/java/efub/assignment/community/global/jwt/TokenProvider.java
@@ -1,0 +1,107 @@
+package efub.assignment.community.global.jwt;
+
+import efub.assignment.community.global.util.RedisUtil;
+import efub.assignment.community.member.domain.Member;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class TokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30L;
+    public static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60L * 24 * 7;
+
+    private final RedisUtil redisUtil;
+
+    public String createAccessToken(Member member){
+        Date now = new Date();
+        return Jwts.builder()
+            .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime()+ACCESS_TOKEN_EXPIRE_TIME))
+            .setSubject(member.getEmail())
+            .signWith(SignatureAlgorithm.HS256,secretKey)
+            .compact();
+    }
+
+    public String createRefreshToken(Member member){
+        Date now = new Date();
+        return Jwts.builder()
+            .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime()+REFRESH_TOKEN_EXPIRE_TIME))
+            .setSubject(member.getEmail())
+            .signWith(SignatureAlgorithm.HS256,secretKey)
+            .compact();
+    }
+
+    public void saveRefreshToken(Long memberId, String refreshToken) {
+        redisUtil.setValues(memberId.toString(), refreshToken, Duration.ofMillis(REFRESH_TOKEN_EXPIRE_TIME));
+    }
+
+    public String extractEmail(String accessToken){
+        if(validateToken(accessToken)){
+            return getClaims(accessToken).getSubject();
+        }
+        return null;
+    }
+
+    public boolean validateToken(String token){
+        try{
+            Jwts.parser()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty", e);
+        }
+        return false;
+    }
+
+
+    public Authentication getAuthentication(String token){
+        Claims claims = getClaims(token);
+
+        Set<SimpleGrantedAuthority> authorities = Collections
+            .singleton(new SimpleGrantedAuthority("ROLE_USER"));
+
+        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails
+            .User(claims.getSubject(), "", authorities), token, authorities);
+    }
+
+    private Claims getClaims(String token){
+        return Jwts.parser()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(token)
+            .getPayload();
+    }
+}

--- a/community/src/main/java/efub/assignment/community/global/oauth/CustomOAuth2UserService.java
+++ b/community/src/main/java/efub/assignment/community/global/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,59 @@
+package efub.assignment.community.global.oauth;
+
+import efub.assignment.community.global.oauth.OAuth2UserInfo;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = new DefaultOAuth2UserService().loadUser(userRequest);
+        Map<String,Object> oAuth2UserAttributes = oAuth2User.getAttributes();
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.from(oAuth2UserAttributes);
+
+        Member member = memberRepository.findByEmail(oAuth2UserInfo.getEmail())
+            .orElseGet(() -> createMember(oAuth2UserInfo));
+
+        Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes());
+        attributes.put("id", member.getMemberId());
+        attributes.put("email", member.getEmail());
+
+        return new DefaultOAuth2User(
+            Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")),
+            attributes,
+            "email"
+        );
+
+    }
+
+    //사용자 생성 메소드
+    private Member createMember(OAuth2UserInfo oAuth2UserInfo) {
+        Member member = Member.builder()
+            .email(oAuth2UserInfo.getEmail())
+            .nickname(oAuth2UserInfo.getNickname())
+            .kakaoId(oAuth2UserInfo.getId())
+            .password(null)
+            .build();
+        return memberRepository.save(member);
+    }
+}

--- a/community/src/main/java/efub/assignment/community/global/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/community/src/main/java/efub/assignment/community/global/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,55 @@
+package efub.assignment.community.global.oauth;
+
+import efub.assignment.community.global.jwt.TokenProvider;
+import efub.assignment.community.member.domain.Member;
+import efub.assignment.community.member.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+
+    private static final String REDIRECT_URL = "/auth/login/success";
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException, ServletException {
+
+        DefaultOAuth2User oAuth2User = (DefaultOAuth2User) authentication.getPrincipal();
+        String email = (String) oAuth2User.getAttributes().get("email");
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(()-> new EntityNotFoundException("해당 이메일을 가진 유저를 찾을 수 없습니다."));
+
+        String accessToken = tokenProvider.createAccessToken(member);
+        String refreshToken = tokenProvider.createRefreshToken(member);
+
+        log.info("accessToken : " + accessToken);
+        log.info("refreshToken : " + refreshToken);
+
+        tokenProvider.saveRefreshToken(member.getMemberId(), refreshToken);
+
+        //여기서 멤버의 상태(예를 들어, NOT_REGISTERED)에 따라 리다이렉트 시킬 페이지를 결정할 수 있음 (주로 회원가입 페이지)
+        String redirectUrl = UriComponentsBuilder
+            .fromUriString(REDIRECT_URL)
+            .queryParam("accessToken", accessToken)
+            .queryParam("refreshToken", refreshToken)
+            .build().toUriString();
+
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/community/src/main/java/efub/assignment/community/global/oauth/OAuth2UserInfo.java
+++ b/community/src/main/java/efub/assignment/community/global/oauth/OAuth2UserInfo.java
@@ -1,0 +1,25 @@
+package efub.assignment.community.global.oauth;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OAuth2UserInfo {
+
+    private Long id;
+    private String email;
+    private String nickname;
+
+    public static OAuth2UserInfo from(Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        Long id = (Long) attributes.get("id");
+        String email = (String) kakaoAccount.get("email");
+        String nickname = (String) profile.get("nickname");
+
+        return new OAuth2UserInfo(id, email, nickname);
+    }
+}

--- a/community/src/main/java/efub/assignment/community/global/util/RedisUtil.java
+++ b/community/src/main/java/efub/assignment/community/global/util/RedisUtil.java
@@ -1,0 +1,36 @@
+package efub.assignment.community.global.util;
+
+import java.time.Duration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisUtil {
+
+    private final RedisTemplate<String,Object> redisTemplate;
+
+    public RedisUtil(RedisTemplate<String,Object> redisTemplate){
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void setValues(String key, String data){
+        ValueOperations<String,Object> values = redisTemplate.opsForValue();
+        values.set(key,data);
+    }
+
+    public void setValues(String key, String data, Duration duration){
+        ValueOperations<String,Object> values = redisTemplate.opsForValue();
+        values.set(key,data,duration);
+    }
+
+    public Object getValues(String key){
+        ValueOperations<String,Object> values = redisTemplate.opsForValue();
+        return values.get(key);
+    }
+
+    public void deleteValues(String key){
+        redisTemplate.delete(key);
+    }
+
+}

--- a/community/src/main/java/efub/assignment/community/member/controller/AuthController.java
+++ b/community/src/main/java/efub/assignment/community/member/controller/AuthController.java
@@ -1,0 +1,26 @@
+package efub.assignment.community.member.controller;
+
+import efub.assignment.community.member.service.AuthService;
+import java.util.HashMap;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/login/success")
+    public ResponseEntity<?> success(String accessToken, String refreshToken) {
+        HashMap<String,String> map = new HashMap<>();
+        map.put("accessToken", accessToken);
+        map.put("refreshToken", refreshToken);
+        return ResponseEntity.ok(map);
+    }
+}

--- a/community/src/main/java/efub/assignment/community/member/domain/Member.java
+++ b/community/src/main/java/efub/assignment/community/member/domain/Member.java
@@ -26,19 +26,21 @@ public class Member extends BaseTimeEntity {
     @Column(name = "member_id", updatable = false)
     private Long memberId;
 
+    @Column(name = "kakao_id")
+    private Long kakaoId;
+
     @Column(nullable = false, length = 60, updatable = false)
     private String email;
 
-    @Column(nullable = false)
     private String password;
 
     @Column(nullable = false, length = 20)
     private String nickname;
 
-    @Column(nullable = false, updatable = false, length = 20)
+    @Column(updatable = false, length = 20)
     private String university;
 
-    @Column(name = "student_id", nullable = false, updatable = false, length = 10)
+    @Column(name = "student_id", updatable = false, length = 10)
     private String studentId;
 
     @ColumnDefault("'REGISTERED'")

--- a/community/src/main/java/efub/assignment/community/member/repository/MemberRepository.java
+++ b/community/src/main/java/efub/assignment/community/member/repository/MemberRepository.java
@@ -9,4 +9,5 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     Boolean existsByEmail(String email);
     Boolean existsByNickname(String nickname);
     Optional<Member> findByNickname(String nickname);
+    Optional<Member> findByEmail(String email);
 }


### PR DESCRIPTION
# 구현 기능
- Spring Security + JWT + OAuth2를 이용한 카카오 로그인 기능 구현
  > 카카오 로그인 성공시 `OAuth2SuccessHandler`를 통해서 `/auth/login/success`로 redirect되도록 구현했음

# 과제 정리
- 카카오 로그인 성공 화면 (`/auth/login/success`로 리다이렉트된 모습)
  ![스크린샷 2024-11-10 225548](https://github.com/user-attachments/assets/df9cdf6e-50ad-4701-99f4-2555ddd19afe)

- DB에 저장된 회원 데이터
  ![image](https://github.com/user-attachments/assets/58be24e3-2292-4724-befb-f1462003bc02)

- Redis에 저장된 Refresh Token
  ![스크린샷 2024-11-10 225732](https://github.com/user-attachments/assets/c46577b7-12c5-4dff-abd9-cd710b1fa879)

# 어려웠던 점
- 카카오 로그인에서 사용할 OAuth Redirect URI를 처음에는 임의로 지정했다가 카카오 로그인에 자꾸 실패했다. 알고보니 Spring Security OAuth2의 Redirect URI는 특정 형식 (`{baseUrl}/login/oauth2/code/{registrationId}`) 에 맞춰 작성해주어야 한다는 걸 알게 되었고, 형식에 맞게 수정하자 기능이 잘 돌아갔다 😭 