### PR TITLE
[황채린] 17주차 과제 제출

### DIFF
--- a/community/build.gradle
+++ b/community/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0" //QueryDSL의 버전을 관리하기 위한 변수 정의
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.4'
@@ -37,8 +43,28 @@ dependencies {
     implementation 'javax.xml.bind:jaxb-api:2.3.1' //XML 문서와 Java 객체 간 매핑 자동화
     /* OAuth2 */
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    /* QueryDSL */
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+
+    annotationProcessor(
+            "jakarta.persistence:jakarta.persistence-api",          //Jakarta Persistence API를 위한 어노테이션 프로세서
+            "jakarta.annotation:jakarta.annotation-api",            //Jakarta Annotation API를 위한 어노테이션 프로세서
+            "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"  //Entity 클래스들에 대해 QueryDSL의 Q타입 클래스를 자동 생성
+    )
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+sourceSets {  //Gradle에서 소스 코드를 찾는 경로를 지정하는 역할
+
+    main {
+        java { //QueryDSL이 생성한 Q타입 클래스들을 build/generated 디렉토리에 저장하도록 설정
+            srcDirs = ["$projectDir/src/main/java", "$projectDir/build/generated"]
+        }
+    }
+}
+
+compileJava.dependsOn('clean') //CompileJava 작업이 clean 작업에 의존하도록 설정

--- a/community/src/main/java/efub/assignment/community/global/config/QueryDslConfig.java
+++ b/community/src/main/java/efub/assignment/community/global/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package efub.assignment.community.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig { //JPAQueryFactory 객체를 빈으로 등록하기 위한 설정 클래스
+
+    private final EntityManager entityManager;
+
+    public QueryDslConfig(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/community/src/main/java/efub/assignment/community/post/controller/PostController.java
+++ b/community/src/main/java/efub/assignment/community/post/controller/PostController.java
@@ -56,4 +56,13 @@ public class PostController {
         postService.deletePost(postId);
         return "게시글을 삭제했습니다.";
     }
+
+    @GetMapping("/search")
+    @ResponseStatus(value = HttpStatus.OK)
+    public PostListResponseDto searchPost(
+        @RequestParam(value = "boardId", required = false) final Long boardId,
+        @RequestParam(value = "writer", required = false) final String writer,
+        @RequestParam(value = "content", required = false) final String content){
+        return postService.searchPost(boardId, writer, content);
+    }
 }

--- a/community/src/main/java/efub/assignment/community/post/repository/CustomPostRepository.java
+++ b/community/src/main/java/efub/assignment/community/post/repository/CustomPostRepository.java
@@ -1,0 +1,8 @@
+package efub.assignment.community.post.repository;
+
+import efub.assignment.community.post.dto.PostDetailsResponseDto;
+import java.util.List;
+
+public interface CustomPostRepository {
+    List<PostDetailsResponseDto> search(Long boardId, String writer, String content);
+}

--- a/community/src/main/java/efub/assignment/community/post/repository/CustomPostRepositoryImpl.java
+++ b/community/src/main/java/efub/assignment/community/post/repository/CustomPostRepositoryImpl.java
@@ -1,0 +1,54 @@
+package efub.assignment.community.post.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import efub.assignment.community.post.domain.QPost;
+import efub.assignment.community.post.dto.PostDetailsResponseDto;
+import java.util.List;
+
+public class CustomPostRepositoryImpl implements CustomPostRepository{
+
+    private final JPAQueryFactory queryFactory;
+
+    public CustomPostRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public List<PostDetailsResponseDto> search(Long boardId, String writer, String content) {
+
+        QPost post = QPost.post;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if(boardId != null) {
+            builder.and(post.board.boardId.eq(boardId));
+        }
+
+        //작성자로 검색 시 익명 처리 된 글도 같이 검색되지 않도록 구현
+        if(writer!=null&& !writer.isEmpty()){
+            builder.and(post.member.nickname.eq(writer).and(
+                post.anonymous.eq(false)
+            ));
+        }
+
+        if(content!=null && !content.isEmpty()){
+            builder.and(post.content.containsIgnoreCase(content)
+                .or(post.content.containsIgnoreCase(content)));
+        }
+
+        return queryFactory
+            .select(Projections.constructor(PostDetailsResponseDto.class
+            , post.postId
+            , post.board.boardId
+            , post.member.nickname
+            , post.anonymous
+            , post.content
+            , post.regDate
+            , post.modDate))
+            .from(post)
+            .where(builder)
+            .fetch();
+    }
+}

--- a/community/src/main/java/efub/assignment/community/post/repository/PostRepository.java
+++ b/community/src/main/java/efub/assignment/community/post/repository/PostRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
-public interface PostRepository extends JpaRepository<Post,Long> {
+public interface PostRepository extends JpaRepository<Post,Long>, CustomPostRepository {
 
     List<Post> findByBoard_BoardId(Long boardId);
 }

--- a/community/src/main/java/efub/assignment/community/post/service/PostService.java
+++ b/community/src/main/java/efub/assignment/community/post/service/PostService.java
@@ -74,4 +74,14 @@ public class PostService {
         postRepository.delete(post);
     }
 
+    public PostListResponseDto searchPost(Long boardId, String writer, String content){
+
+        List<PostDetailsResponseDto> dtoList = postRepository.search(boardId, writer, content);
+
+        return PostListResponseDto.builder()
+            .posts(postRepository.search(boardId, writer, content))
+            .count((long) dtoList.size())
+            .build();
+    }
+
 }


### PR DESCRIPTION
# 구현 기능
- 게시글 검색 API 구현 
  > 게시판 ID / 작성자 닉네임 / 게시글 내용 (키워드 포함 여부) 로 검색 가능 
  > 단, 작성자 닉네임으로 검색 시 anonymous가 true인 게시글은 조회되지 않도록 구현

# 과제 정리
### 아무 검색 조건도 없을 때
  ![20241115_163659](https://github.com/user-attachments/assets/0d74cb71-98e3-4f52-931e-190fbf0a0805)

### `게시판 ID` 으로 검색
  ![20241115_163800](https://github.com/user-attachments/assets/37dfab3b-f0af-40b6-9e22-6752739ddb75)

### `작성자 닉네임` 으로 검색
  ![image](https://github.com/user-attachments/assets/716566dd-40a7-4d15-9a13-5e0c01707892)

### `게시글 내용` 으로 검색
  ![image](https://github.com/user-attachments/assets/d26adb3f-6fec-43be-96d1-fda381865445)

### `게시판 ID` & `작성자 닉네임` 으로 검색
  ![image](https://github.com/user-attachments/assets/b7a80a46-8896-413d-9942-7fc96efdcc1d)

### `게시판 ID` & `게시글 내용` 으로 검색
  ![image](https://github.com/user-attachments/assets/78bd3da2-d369-4727-8aee-26faa6e6e6f3)

### `작성자 닉네임` & `게시글 내용` 으로 검색
  ![image](https://github.com/user-attachments/assets/b55cbc8e-be54-461c-a5d7-e450dc7b661d)

### `게시판 ID` & `작성자 닉네임` & `게시글 내용` 으로 검색
  ![image](https://github.com/user-attachments/assets/dad19874-f56c-4fbf-b592-5e040157d4b3)

# 어려웠던 점(생략 가능)
### `@RequestParam` 인코딩 문제
`작성자 닉네임` 이나 `게시글 내용` 으로 검색을 할 때 요청 URL에 한글을 포함하는 경우 검색 결과가 올바르게 필터링 되지 않는 모습을 볼 수 있었다. 이유를 살펴보니, 원칙적으로 URL에는 ASCII가 아닌 문자를 사용할 수 없기 때문이라고 한다. [ref](https://www.inflearn.com/community/questions/52731/%ED%95%9C%EA%B8%80-%EC%9D%B8%EC%BD%94%EB%94%A9-%EC%98%A4%EB%A5%98?srsltid=AfmBOopRVXKBKASaPyqsCD_thohvQhDaX2iR3rTsyLtRBcojz4KPOwtj)
### 해결 방법 1 : 요청을 보낼 때 한글 문자를 자체적으로 인코딩해 보내기
[링크](https://www.urlencoder.org/ko/) 를 이용해서 요청 보낼 때부터 `http://localhost:8080/posts/search?writer=%ED%8D%BC%EB%B9%84` 처럼 자체적으로 percent encoding 하여 보내기 (번거로움)
### 해결 방법 2 : application.yml 에 설정 추가
```
server:
  tomcat:
    uri-encoding: utf-8
```